### PR TITLE
Archive NapCat expand implementations into `expand.bak` package

### DIFF
--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/bak/NapCatAccountExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/bak/NapCatAccountExpand.kt
@@ -1,0 +1,364 @@
+package com.blr19c.falowp.bot.adapter.nc.expand.bak
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApiSupport
+import com.blr19c.falowp.bot.system.api.ReceiveMessage
+import com.blr19c.falowp.bot.system.expand.ImageUrl
+import com.blr19c.falowp.bot.system.json.Json
+import com.fasterxml.jackson.annotation.JsonProperty
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.node.ArrayNode
+
+/**
+ * 账号类扩展
+ */
+class NapCatAccountExpand {
+
+    /**
+     * 好友信息
+     */
+    data class FriendUser(
+        /**
+         * 用户ID
+         */
+        @field:JsonProperty("user_id")
+        val userId: String,
+        /**
+         * 好友分组ID
+         */
+        @field:JsonProperty("category_id")
+        val categoryId: Int,
+        /**
+         * 昵称
+         */
+        @field:JsonProperty("nickname")
+        val nickname: String,
+        /**
+         * 备注
+         */
+        @field:JsonProperty("remark")
+        val remark: String?,
+        /**
+         * 出生年份
+         */
+        @field:JsonProperty("birthday_year")
+        val birthdayYear: Int?,
+        /**
+         * 出生月份
+         */
+        @field:JsonProperty("birthday_month")
+        val birthdayMonth: Int?,
+        /**
+         * 出生日
+         */
+        @field:JsonProperty("birthday_day")
+        val birthdayDay: Int?,
+        /**
+         * 年龄
+         */
+        @field:JsonProperty("age")
+        val age: Int?,
+        /**
+         * 手机号
+         */
+        @field:JsonProperty("phone_num")
+        val phoneNum: String?,
+        /**
+         * 邮箱
+         */
+        @field:JsonProperty("email")
+        val email: String?,
+        /**
+         * 性别
+         */
+        @field:JsonProperty("sex")
+        val sex: String,
+        /**
+         * 等级
+         */
+        @field:JsonProperty("level")
+        val level: Int
+    ) {
+
+        fun toUser(): ReceiveMessage.User {
+            return ReceiveMessage.User(
+                userId,
+                if (remark.isNullOrBlank()) nickname else remark,
+                NapCatBotApiSupport.apiAuth(userId),
+                NapCatBotApiSupport.avatar(userId)
+            )
+        }
+    }
+}
+
+/**
+ * 设置私聊信息已读
+ *
+ * @param userId 用户id
+ */
+suspend fun NapCatBotApi.markPrivateMsgAsRead(userId: String = this.receiveMessage.sender.id) {
+    apiRequestUnit("mark_private_msg_as_read", mapOf("user_id" to userId))
+}
+
+/**
+ * 设置群聊信息已读
+ *
+ * @param groupId 群组id
+ */
+suspend fun NapCatBotApi.markGroupMsgAsRead(groupId: String = this.receiveMessage.source.id) {
+    apiRequestUnit("mark_group_msg_as_read", mapOf("group_id" to groupId))
+}
+
+/**
+ * 设置所有消息已读
+ */
+suspend fun NapCatBotApi.markAllAsRead() {
+    apiRequestUnit("_mark_all_as_read")
+}
+
+/**
+ * 获取最近的聊天记录
+ */
+suspend fun NapCatBotApi.getRecentContact(): ArrayNode {
+    return apiRequest<ArrayNode>("get_recent_contact") ?: Json.objectMapper().createArrayNode()
+}
+
+/**
+ * 点赞
+ *
+ * @param userId 用户id
+ * @param count 点赞次数（默认1）
+ */
+suspend fun NapCatBotApi.likeUser(userId: String = this.receiveMessage.sender.id, count: Int = 1) {
+    apiRequestUnit("send_like", mapOf("user_id" to userId, "times" to count))
+}
+
+
+/**
+ * 处理好友请求
+ *
+ * @param flag 请求标识
+ * @param approve 是否同意
+ * @param remark 备注
+ */
+suspend fun NapCatBotApi.handleFriendRequest(flag: String, approve: Boolean, remark: String? = null) {
+    apiRequestUnit(
+        "set_friend_add_request", mapOf("flag" to flag, "approve" to approve, "remark" to remark)
+    )
+}
+
+/**
+ * 获取账号信息
+ */
+suspend fun NapCatBotApi.getAccountInfo(): JsonNode? {
+    return apiRequest("get_account_info")
+}
+
+/**
+ * 获取好友列表
+ */
+suspend fun NapCatBotApi.getFriendList(): List<NapCatAccountExpand.FriendUser> {
+    return apiRequest("get_friend_list")
+}
+
+/**
+ * 获取好友分组列表
+ */
+suspend fun NapCatBotApi.getFriendGroupList(): ArrayNode {
+    return apiRequest<ArrayNode>("get_friend_group_list") ?: Json.objectMapper().createArrayNode()
+}
+
+/**
+ * 设置账号信息
+ *
+ * @param nickname 昵称
+ * @param gender 性别（0未知 1男 2女）
+ * @param birthday 生日时间戳
+ */
+suspend fun NapCatBotApi.setAccountInfo(nickname: String, gender: Int, birthday: Long) {
+    apiRequestUnit(
+        "set_account_info", mapOf("nickname" to nickname, "gender" to gender, "birthday" to birthday)
+    )
+}
+
+/**
+ * 删除好友
+ *
+ * @param userId 用户id
+ */
+suspend fun NapCatBotApi.deleteFriend(userId: String = this.receiveMessage.sender.id) {
+    apiRequestUnit("delete_friend", mapOf("user_id" to userId))
+}
+
+/**
+ * 获取推荐好友/群聊卡片
+ */
+suspend fun NapCatBotApi.getRecommendContact(): ArrayNode {
+    return apiRequest<ArrayNode>("get_recommend_contact") ?: Json.objectMapper().createArrayNode()
+}
+
+/**
+ * 获取推荐群聊卡片
+ */
+suspend fun NapCatBotApi.getRecommendGroup(): ArrayNode {
+    return apiRequest<ArrayNode>("get_recommend_group") ?: Json.objectMapper().createArrayNode()
+}
+
+/**
+ * 设置在线状态
+ *
+ * @param status 在线状态
+ */
+suspend fun NapCatBotApi.setOnlineStatus(status: String) {
+    apiRequestUnit("set_online_status", mapOf("status" to status))
+}
+
+/**
+ * 设置自定义在线状态
+ *
+ * @param wording 状态文案
+ * @param emojiId 表情ID
+ */
+suspend fun NapCatBotApi.setCustomOnlineStatus(wording: String, emojiId: String) {
+    apiRequestUnit(
+        "set_custom_online_status", mapOf("wording" to wording, "emoji_id" to emojiId)
+    )
+}
+
+
+/**
+ * 设置头像
+ *
+ * @param image 图片数据
+ */
+suspend fun NapCatBotApi.setAvatar(image: ImageUrl) {
+    apiRequestUnit("set_avatar", mapOf("image" to image.toBase64()))
+}
+
+/**
+ * 创建收藏
+ *
+ * @param content 收藏内容
+ * @param type 收藏类型
+ */
+suspend fun NapCatBotApi.createCollection(content: String, type: Int) {
+    apiRequestUnit(
+        "create_collection", mapOf("content" to content, "type" to type)
+    )
+}
+
+/**
+ * 设置个性签名
+ *
+ * @param signature 签名内容
+ */
+suspend fun NapCatBotApi.setSignature(signature: String) {
+    apiRequestUnit("set_signature", mapOf("signature" to signature))
+}
+
+/**
+ * 获取收藏表情
+ */
+suspend fun NapCatBotApi.getCollectionEmoji(): ArrayNode {
+    return apiRequest<ArrayNode>("get_collection_emoji") ?: Json.objectMapper().createArrayNode()
+}
+
+/**
+ * 获取点赞列表
+ */
+suspend fun NapCatBotApi.getLikeList(): ArrayNode {
+    return apiRequest<ArrayNode>("get_like_list") ?: Json.objectMapper().createArrayNode()
+}
+
+/**
+ * 获取用户状态
+ *
+ * @param userId 用户id
+ */
+suspend fun NapCatBotApi.getUserStatus(userId: String = this.receiveMessage.sender.id): JsonNode? {
+    return apiRequest("get_user_status", mapOf("user_id" to userId))
+}
+
+/**
+ * 获取小程序卡片
+ *
+ * @param appId 小程序appid
+ */
+suspend fun NapCatBotApi.getMiniAppCard(appId: String): JsonNode? {
+    return apiRequest("get_mini_app_card", mapOf("app_id" to appId))
+}
+
+/**
+ * 获取单向好友列表
+ */
+suspend fun NapCatBotApi.getUnidirectionalFriendList(): ArrayNode {
+    return apiRequest<ArrayNode>("get_unidirectional_friend_list") ?: Json.objectMapper().createArrayNode()
+}
+
+/**
+ * 获取登录号信息
+ */
+suspend fun NapCatBotApi.getLoginInfo(): JsonNode? {
+    return apiRequest("get_login_info")
+}
+
+/**
+ * 获取状态
+ */
+suspend fun NapCatBotApi.getStatus(): JsonNode? {
+    return apiRequest("get_status")
+}
+
+/**
+ * 获取当前账号在线客户端列表
+ */
+suspend fun NapCatBotApi.getOnlineClients(): ArrayNode {
+    return apiRequest<ArrayNode>("get_online_clients") ?: Json.objectMapper().createArrayNode()
+}
+
+/**
+ * 获取在线机型
+ */
+suspend fun NapCatBotApi.getOnlineModel(): JsonNode? {
+    return apiRequest("_get_online_model")
+}
+
+/**
+ * 设置在线机型
+ *
+ * @param model 机型
+ */
+suspend fun NapCatBotApi.setOnlineModel(model: String) {
+    apiRequestUnit("_set_online_model", mapOf("model" to model))
+}
+
+/**
+ * 获取被过滤好友请求
+ */
+suspend fun NapCatBotApi.getFilteredFriendRequest(): ArrayNode {
+    return apiRequest<ArrayNode>("get_filtered_friend_request") ?: Json.objectMapper().createArrayNode()
+}
+
+/**
+ * 处理被过滤好友请求
+ *
+ * @param flag 请求标识
+ * @param approve 是否同意
+ */
+suspend fun NapCatBotApi.handleFilteredFriendRequest(flag: String, approve: Boolean) {
+    apiRequestUnit(
+        "handle_filtered_friend_request", mapOf("flag" to flag, "approve" to approve)
+    )
+}
+
+/**
+ * 设置好友备注
+ *
+ * @param userId 用户id
+ * @param remark 备注
+ */
+suspend fun NapCatBotApi.setFriendRemark(userId: String = this.receiveMessage.sender.id, remark: String) {
+    apiRequestUnit(
+        "set_friend_remark", mapOf("user_id" to userId, "remark" to remark)
+    )
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/bak/NapCatFileExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/bak/NapCatFileExpand.kt
@@ -1,0 +1,457 @@
+package com.blr19c.falowp.bot.adapter.nc.expand.bak
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import com.blr19c.falowp.bot.system.json.Json
+import com.fasterxml.jackson.annotation.JsonProperty
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.node.ArrayNode
+import java.net.URI
+
+/**
+ * 文件类扩展
+ */
+class NapCatFileExpand {
+
+    /**
+     * 群文件链接信息
+     */
+    data class GroupFileUrl(
+        /**
+         * 文件链接
+         */
+        @field:JsonProperty("url")
+        val url: URI,
+    )
+
+    /**
+     * 群文件信息
+     */
+    data class GroupFileInfo(
+        val fileId: String,
+        val fileName: String,
+        val size: Long,
+    )
+
+}
+
+/**
+ * 上传群文件
+ *
+ * @param groupId 群组id
+ * @param file 本地文件路径
+ * @param name 文件名（不传则使用原文件名）
+ * @param folderId 目标文件夹id（不传则根目录）
+ */
+suspend fun NapCatBotApi.uploadGroupFile(
+    groupId: String = this.receiveMessage.source.id,
+    file: String,
+    name: String? = null,
+    folderId: String? = null
+) {
+    apiRequestUnit(
+        "upload_group_file",
+        mapOf(
+            "group_id" to groupId,
+            "file" to file,
+            "name" to name,
+            "folder_id" to folderId
+        )
+    )
+}
+
+/**
+ * 上传私聊文件
+ *
+ * @param userId 用户id
+ * @param file 本地文件路径
+ * @param name 文件名（不传则使用原文件名）
+ */
+suspend fun NapCatBotApi.uploadPrivateFile(
+    userId: String = this.receiveMessage.sender.id,
+    file: String,
+    name: String? = null
+) {
+    apiRequestUnit(
+        "upload_private_file",
+        mapOf(
+            "user_id" to userId,
+            "file" to file,
+            "name" to name
+        )
+    )
+}
+
+/**
+ * 获取群根目录文件列表
+ *
+ * @param groupId 群组id
+ * @return 根目录文件列表
+ */
+suspend fun NapCatBotApi.getGroupRootFiles(
+    groupId: String = this.receiveMessage.source.id
+): JsonNode? {
+    return apiRequest(
+        "get_group_root_files",
+        mapOf("group_id" to groupId)
+    )
+}
+
+/**
+ * 获取群子目录文件列表
+ *
+ * @param groupId 群组id
+ * @param folderId 文件夹id
+ * @return 子目录文件列表
+ */
+suspend fun NapCatBotApi.getGroupFilesByFolder(
+    groupId: String = this.receiveMessage.source.id,
+    folderId: String
+): JsonNode? {
+    return apiRequest(
+        "get_group_files_by_folder",
+        mapOf(
+            "group_id" to groupId,
+            "folder_id" to folderId
+        )
+    )
+}
+
+/**
+ * 获取群文件系统信息
+ *
+ * @param groupId 群组id
+ * @return 文件系统信息
+ */
+suspend fun NapCatBotApi.getGroupFileSystemInfo(
+    groupId: String = this.receiveMessage.source.id
+): JsonNode? {
+    return apiRequest(
+        "get_group_file_system_info",
+        mapOf("group_id" to groupId)
+    )
+}
+
+/**
+ * 获取文件信息
+ *
+ * @param fileId 文件id
+ * @return 文件信息
+ */
+suspend fun NapCatBotApi.getFileInfo(fileId: String): JsonNode? {
+    return apiRequest(
+        "get_file_info",
+        mapOf("file_id" to fileId)
+    )
+}
+
+/**
+ * 获取群文件链接
+ *
+ * @param groupId 群组id
+ * @param fileId 文件id
+ * @param busid 业务id（部分实现需要）
+ * @return 文件链接信息
+ */
+suspend fun NapCatBotApi.getGroupFileUrl(
+    groupId: String = this.receiveMessage.source.id,
+    fileId: String,
+    busid: Int? = null
+): NapCatFileExpand.GroupFileUrl {
+    return apiRequest(
+        "get_group_file_url",
+        mapOf(
+            "group_id" to groupId,
+            "file_id" to fileId,
+            "busid" to busid
+        )
+    )
+}
+
+
+/**
+ * 获取私聊文件链接
+ *
+ * @param userId 用户id
+ * @param fileId 文件id
+ * @return 文件链接信息
+ */
+suspend fun NapCatBotApi.getPrivateFileUrl(
+    userId: String = this.receiveMessage.sender.id,
+    fileId: String
+): JsonNode? {
+    return apiRequest(
+        "get_private_file_url",
+        mapOf(
+            "user_id" to userId,
+            "file_id" to fileId
+        )
+    )
+}
+
+/**
+ * 创建群文件文件夹
+ *
+ * @param groupId 群组id
+ * @param name 文件夹名称
+ * @param parentId 父文件夹id（不传则根目录）
+ */
+suspend fun NapCatBotApi.createGroupFileFolder(
+    groupId: String = this.receiveMessage.source.id,
+    name: String,
+    parentId: String? = null
+) {
+    apiRequestUnit(
+        "create_group_file_folder",
+        mapOf(
+            "group_id" to groupId,
+            "name" to name,
+            "parent_id" to parentId
+        )
+    )
+}
+
+/**
+ * 删除群文件
+ *
+ * @param groupId 群组id
+ * @param fileId 文件id
+ * @param busid 业务id（部分实现需要）
+ */
+suspend fun NapCatBotApi.deleteGroupFile(
+    groupId: String = this.receiveMessage.source.id,
+    fileId: String,
+    busid: Int? = null
+) {
+    apiRequestUnit(
+        "delete_group_file",
+        mapOf(
+            "group_id" to groupId,
+            "file_id" to fileId,
+            "busid" to busid
+        )
+    )
+}
+
+/**
+ * 删除群文件夹
+ *
+ * @param groupId 群组id
+ * @param folderId 文件夹id
+ */
+suspend fun NapCatBotApi.deleteGroupFolder(
+    groupId: String = this.receiveMessage.source.id,
+    folderId: String
+) {
+    apiRequestUnit(
+        "delete_group_folder",
+        mapOf(
+            "group_id" to groupId,
+            "folder_id" to folderId
+        )
+    )
+}
+
+/**
+ * 移动群文件
+ *
+ * @param groupId 群组id
+ * @param fileId 文件id
+ * @param destFolderId 目标文件夹id（不传则根目录）
+ */
+suspend fun NapCatBotApi.moveGroupFile(
+    groupId: String = this.receiveMessage.source.id,
+    fileId: String,
+    destFolderId: String? = null
+) {
+    apiRequestUnit(
+        "move_group_file",
+        mapOf(
+            "group_id" to groupId,
+            "file_id" to fileId,
+            "dest_folder_id" to destFolderId
+        )
+    )
+}
+
+/**
+ * 重命名群文件
+ *
+ * @param groupId 群组id
+ * @param fileId 文件id
+ * @param name 新文件名
+ */
+suspend fun NapCatBotApi.renameGroupFile(
+    groupId: String = this.receiveMessage.source.id,
+    fileId: String,
+    name: String
+) {
+    apiRequestUnit(
+        "rename_group_file",
+        mapOf(
+            "group_id" to groupId,
+            "file_id" to fileId,
+            "name" to name
+        )
+    )
+}
+
+/**
+ * 转存为永久文件
+ *
+ * @param fileId 文件id
+ * @return 转存结果
+ */
+suspend fun NapCatBotApi.saveFileToPermanent(
+    fileId: String
+): JsonNode {
+    return apiRequest(
+        "save_file_to_permanent",
+        mapOf("file_id" to fileId)
+    )
+}
+
+/**
+ * 下载文件到缓存目录
+ *
+ * @param url 文件url
+ * @param name 保存文件名（可选）
+ * @return 下载结果（通常包含缓存路径）
+ */
+suspend fun NapCatBotApi.downloadFileToCache(
+    url: String,
+    name: String? = null
+): JsonNode? {
+    return apiRequest(
+        "download_file_to_cache",
+        mapOf(
+            "url" to url,
+            "name" to name
+        )
+    )
+}
+
+/**
+ * 清空缓存
+ */
+suspend fun NapCatBotApi.clearCache() {
+    apiRequestUnit("clear_cache")
+}
+
+/**
+ * 删除群相册文件
+ *
+ * @param groupId 群组id
+ * @param albumId 相册id
+ * @param fileId 文件id
+ */
+suspend fun NapCatBotApi.deleteGroupAlbumFile(
+    groupId: String = this.receiveMessage.source.id,
+    albumId: String,
+    fileId: String
+) {
+    apiRequestUnit(
+        "delete_group_album_file",
+        mapOf(
+            "group_id" to groupId,
+            "album_id" to albumId,
+            "file_id" to fileId
+        )
+    )
+}
+
+/**
+ * 点赞群相册
+ *
+ * @param groupId 群组id
+ * @param albumId 相册id
+ * @param fileId 文件id
+ * @param like 是否点赞
+ */
+suspend fun NapCatBotApi.likeGroupAlbum(
+    groupId: String = this.receiveMessage.source.id,
+    albumId: String,
+    fileId: String,
+    like: Boolean = true
+) {
+    apiRequestUnit(
+        "like_group_album",
+        mapOf(
+            "group_id" to groupId,
+            "album_id" to albumId,
+            "file_id" to fileId,
+            "like" to like
+        )
+    )
+}
+
+/**
+ * 查看群相册评论
+ *
+ * @param groupId 群组id
+ * @param albumId 相册id
+ * @param fileId 文件id
+ * @return 评论列表
+ */
+suspend fun NapCatBotApi.getGroupAlbumComments(
+    groupId: String = this.receiveMessage.source.id,
+    albumId: String,
+    fileId: String
+): ArrayNode {
+    return apiRequest<ArrayNode>(
+        "get_group_album_comments",
+        mapOf(
+            "group_id" to groupId,
+            "album_id" to albumId,
+            "file_id" to fileId
+        )
+    ) ?: Json.objectMapper().createArrayNode()
+}
+
+/**
+ * 获取群相册列表
+ *
+ * @param groupId 群组id
+ * @return 相册列表
+ */
+suspend fun NapCatBotApi.getGroupAlbumList(
+    groupId: String = this.receiveMessage.source.id
+): ArrayNode {
+    return apiRequest<ArrayNode>(
+        "get_group_album_list",
+        mapOf("group_id" to groupId)
+    ) ?: Json.objectMapper().createArrayNode()
+}
+
+/**
+ * 上传图片到群相册
+ *
+ * @param groupId 群组id
+ * @param albumId 相册id
+ * @param file 本地图片路径
+ * @param name 图片名（可选）
+ */
+suspend fun NapCatBotApi.uploadImageToGroupAlbum(
+    groupId: String = this.receiveMessage.source.id,
+    albumId: String,
+    file: String,
+    name: String? = null
+) {
+    apiRequestUnit(
+        "upload_image_to_group_album",
+        mapOf(
+            "group_id" to groupId,
+            "album_id" to albumId,
+            "file" to file,
+            "name" to name
+        )
+    )
+}
+
+/**
+ * 获取群相册总列表
+ *
+ * @return 群相册总列表
+ */
+suspend fun NapCatBotApi.getGroupAlbumTotalList(): ArrayNode {
+    return apiRequest<ArrayNode>("get_group_album_total_list")
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/bak/NapCatGroupExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/bak/NapCatGroupExpand.kt
@@ -1,0 +1,827 @@
+package com.blr19c.falowp.bot.adapter.nc.expand.bak
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApiSupport
+import com.blr19c.falowp.bot.adapter.nc.message.NapCatMessage
+import com.blr19c.falowp.bot.system.api.ReceiveMessage
+import com.blr19c.falowp.bot.system.expand.ImageUrl
+import com.blr19c.falowp.bot.system.json.Json
+import com.fasterxml.jackson.annotation.JsonProperty
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.node.ArrayNode
+
+/**
+ * 群聊类扩展
+ */
+class NapCatGroupExpand {
+
+    /**
+     * 群信息
+     */
+    data class GroupInfo(
+        /**
+         * 群号
+         */
+        @field:JsonProperty("group_id")
+        val groupId: String,
+
+        /**
+         * 是否全员禁言
+         */
+        @field:JsonProperty("group_all_shut")
+        val groupAllShut: Int,
+
+        /**
+         * 群备注
+         */
+        @field:JsonProperty("group_remark")
+        val groupRemark: String,
+
+        /**
+         * 群名称
+         */
+        @field:JsonProperty("group_name")
+        val groupName: String,
+
+        /**
+         * 成员人数
+         */
+        @field:JsonProperty("member_count")
+        val memberCount: Int? = null,
+
+        /**
+         * 最大成员人数
+         */
+        @field:JsonProperty("max_member_count")
+        val maxMemberCount: Int? = null
+    )
+
+    /**
+     * 群成员信息
+     */
+    data class GroupMember(
+        /**
+         * 群ID
+         */
+        @field:JsonProperty("group_id")
+        val groupId: String,
+
+        /**
+         * 用户ID
+         */
+        @field:JsonProperty("user_id")
+        val userId: String,
+
+        /**
+         * 昵称
+         */
+        @field:JsonProperty("nickname")
+        val nickname: String,
+
+        /**
+         * 群成员角色
+         */
+        @field:JsonProperty("role")
+        val role: String,
+
+        /**
+         * 群头衔
+         */
+        @field:JsonProperty("title")
+        val title: String? = null,
+
+        /**
+         * 群名片
+         */
+        @field:JsonProperty("card")
+        val card: String? = null,
+
+        /**
+         * 性别
+         */
+        @field:JsonProperty("sex")
+        val sex: String? = null,
+
+        /**
+         * 年龄
+         */
+        @field:JsonProperty("age")
+        val age: Int? = null,
+
+        /**
+         * 地区
+         */
+        @field:JsonProperty("area")
+        val area: String? = null,
+
+        /**
+         * 群等级
+         */
+        @field:JsonProperty("level")
+        val level: Int? = null,
+
+        /**
+         * QQ 等级
+         */
+        @field:JsonProperty("qq_level")
+        val qqLevel: Int? = null,
+
+        /**
+         * 加群时间
+         */
+        @field:JsonProperty("join_time")
+        val joinTime: Long? = null,
+
+        /**
+         * 最后发言时间
+         */
+        @field:JsonProperty("last_sent_time")
+        val lastSentTime: Long? = null,
+
+        /**
+         * 头衔过期时间
+         */
+        @field:JsonProperty("title_expire_time")
+        val titleExpireTime: Long? = null,
+
+        /**
+         * 是否机器人
+         */
+        @field:JsonProperty("is_robot")
+        val isRobot: Boolean,
+
+        /**
+         * 禁言到期时间戳
+         * 0 表示未禁言
+         */
+        @field:JsonProperty("shut_up_timestamp")
+        val shutUpTimestamp: Long,
+    ) {
+
+        fun toUser(): ReceiveMessage.User {
+            return ReceiveMessage.User(
+                userId,
+                if (card.isNullOrBlank()) nickname else card,
+                NapCatBotApiSupport.apiAuth(userId, role),
+                NapCatBotApiSupport.avatar(userId)
+            )
+        }
+    }
+
+    /**
+     * 精华消息
+     */
+    data class EssenceMsg(
+        /**
+         * 消息 ID
+         */
+        @field:JsonProperty("message_id")
+        val messageId: String,
+
+        /**
+         * 发送人
+         */
+        @field:JsonProperty("sender_id")
+        val senderId: String,
+
+        /**
+         * 操作人
+         */
+        @field:JsonProperty("operator_id")
+        val operatorId: String,
+
+        /**
+         * 操作时间
+         */
+        @field:JsonProperty("operator_time")
+        val operatorTime: Long,
+
+        /**
+         * 消息内容
+         */
+        @field:JsonProperty("content")
+        val content: List<NapCatMessage.Message>
+    )
+
+
+}
+
+/**
+ * 设置群添加选项
+ *
+ * @param groupId 群组id
+ * @param addType 加群方式（例如：0允许任何人 1需要验证 2不允许加群）
+ * @param question 验证问题
+ * @param answer 验证答案
+ */
+suspend fun NapCatBotApi.setGroupAddOption(
+    groupId: String = this.receiveMessage.source.id,
+    addType: Int,
+    question: String? = null,
+    answer: String? = null
+) {
+    apiRequestUnit(
+        "set_group_add_option",
+        mapOf(
+            "group_id" to groupId,
+            "add_type" to addType,
+            "question" to question,
+            "answer" to answer
+        )
+    )
+}
+
+/**
+ * 设置群机器人添加选项
+ *
+ * @param groupId 群组id
+ * @param enable 是否允许机器人被添加
+ */
+suspend fun NapCatBotApi.setGroupBotAddOption(
+    groupId: String = this.receiveMessage.source.id,
+    enable: Boolean
+) {
+    apiRequestUnit(
+        "set_group_bot_add_option",
+        mapOf(
+            "group_id" to groupId,
+            "enable" to enable
+        )
+    )
+}
+
+/**
+ * 批量踢出群成员
+ *
+ * @param groupId 群组id
+ * @param userIds 用户id列表
+ * @param rejectAddRequest 是否拒绝再次申请
+ */
+suspend fun NapCatBotApi.batchGroupKick(
+    groupId: String = this.receiveMessage.source.id,
+    userIds: List<String>,
+    rejectAddRequest: Boolean = false
+) {
+    apiRequestUnit(
+        "batch_group_kick",
+        mapOf(
+            "group_id" to groupId,
+            "user_ids" to userIds,
+            "reject_add_request" to rejectAddRequest
+        )
+    )
+}
+
+/**
+ * 设置群备注
+ *
+ * @param groupId 群组id
+ * @param remark 群备注
+ */
+suspend fun NapCatBotApi.setGroupRemark(
+    groupId: String = this.receiveMessage.source.id,
+    remark: String
+) {
+    apiRequestUnit(
+        "set_group_remark",
+        mapOf(
+            "group_id" to groupId,
+            "remark" to remark
+        )
+    )
+}
+
+/**
+ * 设置群头衔
+ *
+ * @param groupId 群组id
+ * @param userId 用户id
+ * @param specialTitle 群头衔
+ * @param duration 持续时间（秒，0通常表示永久）
+ */
+suspend fun NapCatBotApi.setGroupSpecialTitle(
+    groupId: String = this.receiveMessage.source.id,
+    userId: String = this.receiveMessage.sender.id,
+    specialTitle: String,
+    duration: Long = 0
+) {
+    apiRequestUnit(
+        "set_group_special_title",
+        mapOf(
+            "group_id" to groupId,
+            "user_id" to userId,
+            "special_title" to specialTitle,
+            "duration" to duration
+        )
+    )
+}
+
+/**
+ * 获取群详细信息
+ *
+ * @param groupId 群组id
+ * @return 群详细信息
+ */
+suspend fun NapCatBotApi.getGroupDetailInfo(
+    groupId: String = this.receiveMessage.source.id
+): JsonNode? {
+    return apiRequest(
+        "get_group_detail_info",
+        mapOf("group_id" to groupId)
+    )
+}
+
+/**
+ * 群踢人
+ *
+ * @param groupId 群组id
+ * @param userId 用户id
+ * @param rejectAddRequest 是否拒绝再次申请
+ */
+suspend fun NapCatBotApi.setGroupKick(
+    groupId: String = this.receiveMessage.source.id,
+    userId: String = this.receiveMessage.sender.id,
+    rejectAddRequest: Boolean = false
+) {
+    apiRequestUnit(
+        "set_group_kick",
+        mapOf(
+            "group_id" to groupId,
+            "user_id" to userId,
+            "reject_add_request" to rejectAddRequest
+        )
+    )
+}
+
+/**
+ * 获取群系统消息
+ *
+ * @return 群系统消息
+ */
+suspend fun NapCatBotApi.getGroupSystemMsg(): JsonNode? {
+    return apiRequest("get_group_system_msg")
+}
+
+/**
+ * 群禁言
+ *
+ * @param groupId 群组id
+ * @param userId 用户id
+ * @param duration 禁言时长（秒）
+ */
+suspend fun NapCatBotApi.setGroupBan(
+    groupId: String = this.receiveMessage.source.id,
+    userId: String = this.receiveMessage.sender.id,
+    duration: Long
+) {
+    apiRequestUnit(
+        "set_group_ban",
+        mapOf(
+            "group_id" to groupId,
+            "user_id" to userId,
+            "duration" to duration
+        )
+    )
+}
+
+/**
+ * 获取群精华消息
+ *
+ * @param groupId 群组id
+ * @return 群精华消息列表
+ */
+suspend fun NapCatBotApi.getEssenceMsgList(
+    groupId: String = this.receiveMessage.source.id
+): List<NapCatGroupExpand.EssenceMsg> {
+    return apiRequest(
+        "get_essence_msg_list",
+        mapOf("group_id" to groupId)
+    )
+}
+
+/**
+ * 全体禁言
+ *
+ * @param groupId 群组id
+ * @param enable 是否开启全体禁言
+ */
+suspend fun NapCatBotApi.setGroupWholeBan(
+    groupId: String = this.receiveMessage.source.id,
+    enable: Boolean
+) {
+    apiRequestUnit(
+        "set_group_whole_ban",
+        mapOf(
+            "group_id" to groupId,
+            "enable" to enable
+        )
+    )
+}
+
+/**
+ * 设置群头像
+ *
+ * @param groupId 群组id
+ * @param image 图片base64或url
+ */
+suspend fun NapCatBotApi.setGroupAvatar(
+    groupId: String = this.receiveMessage.source.id,
+    image: String
+) {
+    apiRequestUnit(
+        "set_group_portrait",
+        mapOf(
+            "group_id" to groupId,
+            "image" to image
+        )
+    )
+}
+
+
+/**
+ * 设置群管理
+ *
+ * @param groupId 群组id
+ * @param userId 用户id
+ * @param enable 是否设为管理员
+ */
+suspend fun NapCatBotApi.setGroupAdmin(
+    groupId: String = this.receiveMessage.source.id,
+    userId: String = this.receiveMessage.sender.id,
+    enable: Boolean
+) {
+    apiRequestUnit(
+        "set_group_admin",
+        mapOf(
+            "group_id" to groupId,
+            "user_id" to userId,
+            "enable" to enable
+        )
+    )
+}
+
+/**
+ * 设置群成员名片
+ *
+ * @param groupId 群组id
+ * @param userId 用户id
+ * @param card 群名片
+ */
+suspend fun NapCatBotApi.setGroupCard(
+    groupId: String = this.receiveMessage.source.id,
+    userId: String = this.receiveMessage.sender.id,
+    card: String
+) {
+    apiRequestUnit(
+        "set_group_card",
+        mapOf(
+            "group_id" to groupId,
+            "user_id" to userId,
+            "card" to card
+        )
+    )
+}
+
+/**
+ * 设置群精华消息
+ *
+ * @param messageId 消息id
+ */
+suspend fun NapCatBotApi.setEssenceMsg(messageId: Long) {
+    apiRequestUnit(
+        "set_essence_msg",
+        mapOf("message_id" to messageId)
+    )
+}
+
+/**
+ * 设置群名
+ *
+ * @param groupId 群组id
+ * @param groupName 群名
+ */
+suspend fun NapCatBotApi.setGroupName(
+    groupId: String = this.receiveMessage.source.id,
+    groupName: String
+) {
+    apiRequestUnit(
+        "set_group_name",
+        mapOf(
+            "group_id" to groupId,
+            "group_name" to groupName
+        )
+    )
+}
+
+/**
+ * 删除群精华消息
+ *
+ * @param messageId 消息id
+ */
+suspend fun NapCatBotApi.deleteEssenceMsg(messageId: Long) {
+    apiRequestUnit(
+        "delete_essence_msg",
+        mapOf("message_id" to messageId)
+    )
+}
+
+/**
+ * 删除群公告
+ *
+ * @param groupId 群组id
+ * @param noticeId 公告id
+ */
+suspend fun NapCatBotApi.deleteGroupNotice(
+    groupId: String = this.receiveMessage.source.id,
+    noticeId: String
+) {
+    apiRequestUnit(
+        "_delete_group_notice",
+        mapOf(
+            "group_id" to groupId,
+            "notice_id" to noticeId
+        )
+    )
+}
+
+/**
+ * 退群
+ *
+ * @param groupId 群组id
+ * @param isDismiss 是否解散（仅群主可用）
+ */
+suspend fun NapCatBotApi.setGroupLeave(
+    groupId: String = this.receiveMessage.source.id,
+    isDismiss: Boolean = false
+) {
+    apiRequestUnit(
+        "set_group_leave",
+        mapOf(
+            "group_id" to groupId,
+            "is_dismiss" to isDismiss
+        )
+    )
+}
+
+/**
+ * 发送群公告
+ *
+ * @param groupId 群组id
+ * @param content 公告内容
+ * @param image 图片base64或url
+ */
+suspend fun NapCatBotApi.sendGroupNotice(
+    groupId: String = this.receiveMessage.source.id,
+    content: String,
+    image: ImageUrl? = null
+) {
+    apiRequestUnit(
+        "_send_group_notice",
+        mapOf(
+            "group_id" to groupId,
+            "content" to content,
+            "image" to image?.toBase64()
+        )
+    )
+}
+
+/**
+ * 设置群搜索
+ *
+ * @param groupId 群组id
+ * @param enable 是否允许被搜索到
+ */
+suspend fun NapCatBotApi.setGroupSearch(
+    groupId: String = this.receiveMessage.source.id,
+    enable: Boolean
+) {
+    apiRequestUnit(
+        "set_group_search",
+        mapOf(
+            "group_id" to groupId,
+            "enable" to enable
+        )
+    )
+}
+
+/**
+ * 获取群公告
+ *
+ * @param groupId 群组id
+ * @return 群公告列表/详情
+ */
+suspend fun NapCatBotApi.getGroupNotice(
+    groupId: String = this.receiveMessage.source.id
+): JsonNode? {
+    return apiRequest(
+        "_get_group_notice",
+        mapOf("group_id" to groupId)
+    )
+}
+
+/**
+ * 处理加群请求
+ *
+ * @param flag 请求标识
+ * @param subType 请求类型（add/invite等）
+ * @param approve 是否同意
+ * @param reason 拒绝理由
+ */
+suspend fun NapCatBotApi.handleGroupAddRequest(
+    flag: String,
+    subType: String,
+    approve: Boolean,
+    reason: String? = null
+) {
+    apiRequestUnit(
+        "set_group_add_request",
+        mapOf(
+            "flag" to flag,
+            "sub_type" to subType,
+            "approve" to approve,
+            "reason" to reason
+        )
+    )
+}
+
+/**
+ * 获取群信息
+ *
+ * @param groupId 群组id
+ * @param noCache 是否不使用缓存
+ * @return 群信息
+ */
+suspend fun NapCatBotApi.getGroupInfo(
+    groupId: String = this.receiveMessage.source.id,
+    noCache: Boolean = false
+): JsonNode? {
+    return apiRequest(
+        "get_group_info",
+        mapOf(
+            "group_id" to groupId,
+            "no_cache" to noCache
+        )
+    )
+}
+
+/**
+ * 获取群列表
+ *
+ * @return 群列表
+ */
+suspend fun NapCatBotApi.getGroupList(): List<NapCatGroupExpand.GroupInfo> {
+    return apiRequest("get_group_list")
+}
+
+/**
+ * 获取群成员信息
+ *
+ * @param groupId 群组id
+ * @param userId 用户id
+ * @param noCache 是否不使用缓存
+ * @return 群成员信息
+ */
+suspend fun NapCatBotApi.getGroupMemberInfo(
+    groupId: String = this.receiveMessage.source.id,
+    userId: String = this.receiveMessage.sender.id,
+    noCache: Boolean = false
+): NapCatGroupExpand.GroupMember {
+    return apiRequest(
+        "get_group_member_info",
+        mapOf(
+            "group_id" to groupId,
+            "user_id" to userId,
+            "no_cache" to noCache
+        )
+    )
+}
+
+/**
+ * 获取群成员列表
+ *
+ * @param groupId 群组id
+ * @return 群成员列表
+ */
+suspend fun NapCatBotApi.getGroupMemberList(
+    groupId: String = this.receiveMessage.source.id,
+    noCache: Boolean = false
+): List<NapCatGroupExpand.GroupMember> {
+    return apiRequest(
+        "get_group_member_list",
+        mapOf("group_id" to groupId, "no_cache" to noCache)
+    ) ?: emptyList()
+}
+
+/**
+ * 获取群荣誉
+ *
+ * @param groupId 群组id
+ * @param type 类型（talkative / performer / legend / strong_newbie / emotion 等）
+ * @return 群荣誉信息
+ */
+suspend fun NapCatBotApi.getGroupHonorInfo(
+    groupId: String = this.receiveMessage.source.id,
+    type: String
+): JsonNode? {
+    return apiRequest(
+        "get_group_honor_info",
+        mapOf(
+            "group_id" to groupId,
+            "type" to type
+        )
+    )
+}
+
+/**
+ * 获取群信息ex
+ *
+ * @param groupId 群组id
+ * @return 群信息ex
+ */
+suspend fun NapCatBotApi.getGroupInfoEx(
+    groupId: String = this.receiveMessage.source.id
+): JsonNode? {
+    return apiRequest(
+        "get_group_info_ex",
+        mapOf("group_id" to groupId)
+    )
+}
+
+/**
+ * 获取群 @全体成员 剩余次数
+ *
+ * @param groupId 群组id
+ * @return 剩余次数信息
+ */
+suspend fun NapCatBotApi.getGroupAtAllRemain(
+    groupId: String = this.receiveMessage.source.id
+): JsonNode? {
+    return apiRequest(
+        "get_group_at_all_remain",
+        mapOf("group_id" to groupId)
+    )
+}
+
+/**
+ * 获取群禁言列表
+ *
+ * @param groupId 群组id
+ * @return 群禁言列表
+ */
+suspend fun NapCatBotApi.getGroupBanList(
+    groupId: String = this.receiveMessage.source.id
+): ArrayNode {
+    return apiRequest<ArrayNode>(
+        "get_group_ban_list",
+        mapOf("group_id" to groupId)
+    ) ?: Json.objectMapper().createArrayNode()
+}
+
+/**
+ * 获取群过滤系统消息
+ *
+ * @return 群过滤系统消息
+ */
+suspend fun NapCatBotApi.getGroupFilteredSystemMsg(): JsonNode? {
+    return apiRequest("get_group_filtered_system_msg")
+}
+
+/**
+ * 群打卡
+ *
+ * @param groupId 群组id
+ */
+suspend fun NapCatBotApi.groupSignIn(
+    groupId: String = this.receiveMessage.source.id
+) {
+    apiRequestUnit(
+        "group_sign_in",
+        mapOf("group_id" to groupId)
+    )
+}
+
+/**
+ * 设置群代办
+ *
+ * @param groupId 群组id
+ * @param title 代办标题
+ * @param content 代办内容
+ * @param enable 是否启用
+ */
+suspend fun NapCatBotApi.setGroupTodo(
+    groupId: String = this.receiveMessage.source.id,
+    title: String,
+    content: String,
+    enable: Boolean = true
+) {
+    apiRequestUnit(
+        "set_group_todo",
+        mapOf(
+            "group_id" to groupId,
+            "title" to title,
+            "content" to content,
+            "enable" to enable
+        )
+    )
+}
+

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/bak/NapCatMessageExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/bak/NapCatMessageExpand.kt
@@ -1,0 +1,209 @@
+package com.blr19c.falowp.bot.adapter.nc.expand.bak
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import com.blr19c.falowp.bot.adapter.nc.message.NapCatMessage
+import com.blr19c.falowp.bot.system.json.Json
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.node.ArrayNode
+
+/**
+ * 消息类扩展
+ */
+class NapCatMessageExpand
+
+/**
+ * 发送群聊消息
+ *
+ * @param groupId 群聊ID
+ * @param message 消息内容
+ */
+suspend fun NapCatBotApi.sendGroupMsg(
+    groupId: String = this.receiveMessage.source.id, message: List<NapCatMessage.Message>
+): Long {
+    val body = mapOf("group_id" to groupId, "message" to message)
+    return apiRequest<Long>("send_group_msg", body)
+}
+
+/**
+ * 发送私聊消息
+ *
+ * @param userId 用户ID
+ * @param message 消息内容
+ */
+suspend fun NapCatBotApi.sendPrivateMsg(
+    userId: String = this.receiveMessage.sender.id, message: List<NapCatMessage.Message>
+): Long {
+    val body = mapOf("user_id" to userId, "message" to message)
+    return apiRequest<Long>("send_private_msg", body)
+}
+
+/**
+ * 发送戳一戳
+ *
+ * @param userId 用户id
+ * @param groupId 群组id
+ */
+suspend fun NapCatBotApi.sendPoke(
+    userId: String = this.receiveMessage.sender.id,
+    groupId: String? = if (this.receiveMessage.group()) this.receiveMessage.source.id else null
+) {
+    apiRequestUnit(
+        "send_poke", mapOf("group_id" to groupId, "user_id" to userId)
+    )
+}
+
+/**
+ * 撤回消息
+ *
+ * @param messageId 消息id
+ */
+suspend fun NapCatBotApi.deleteMsg(messageId: String) {
+    apiRequestUnit("delete_msg", mapOf("message_id" to messageId))
+}
+
+/**
+ * 获取群历史消息
+ *
+ * @param groupId 群组id
+ * @param messageSeq 起始消息序号（可选，不传一般表示从最新开始）
+ * @param count 获取数量（默认20）
+ * @return 群历史消息列表
+ */
+suspend fun NapCatBotApi.getGroupMsgHistory(
+    groupId: String = this.receiveMessage.source.id, messageSeq: Long? = null, count: Int = 20
+): ArrayNode {
+    return apiRequest<ArrayNode>(
+        "get_group_msg_history",
+        mapOf("group_id" to groupId, "message_seq" to messageSeq, "count" to count)
+    ) ?: Json.objectMapper().createArrayNode()
+}
+
+/**
+ * 获取消息详情
+ *
+ * @param messageId 消息id
+ * @return 消息详情
+ */
+suspend fun NapCatBotApi.getMsg(messageId: String): NapCatMessage {
+    return apiRequest("get_msg", mapOf("message_id" to messageId)) ?: throw IllegalArgumentException("无效的消息ID")
+}
+
+/**
+ * 获取合并转发消息
+ *
+ * @param id 合并转发id
+ * @return 合并转发消息内容
+ */
+suspend fun NapCatBotApi.getForwardMsg(id: String): JsonNode? {
+    return apiRequest("get_forward_msg", mapOf("id" to id))
+}
+
+/**
+ * 贴表情
+ *
+ * @param messageId 消息id
+ * @param emojiId 表情id
+ * @param set 是否贴上（true贴上 / false取消）
+ */
+suspend fun NapCatBotApi.setMsgEmojiLike(messageId: Long, emojiId: String, set: Boolean = true) {
+    apiRequestUnit(
+        "set_msg_emoji_like",
+        mapOf("message_id" to messageId, "emoji_id" to emojiId, "set" to set)
+    )
+}
+
+/**
+ * 获取好友历史消息
+ *
+ * @param userId 用户id
+ * @param messageSeq 起始消息序号（可选，不传一般表示从最新开始）
+ * @param count 获取数量（默认20）
+ * @return 好友历史消息列表
+ */
+suspend fun NapCatBotApi.getFriendMsgHistory(
+    userId: String = this.receiveMessage.sender.id,
+    messageSeq: Long? = null,
+    count: Int = 20
+): ArrayNode {
+    return apiRequest<ArrayNode>(
+        "get_friend_msg_history",
+        mapOf("user_id" to userId, "message_seq" to messageSeq, "count" to count)
+    ) ?: Json.objectMapper().createArrayNode()
+}
+
+/**
+ * 获取贴表情详情
+ *
+ * @param messageId 消息id
+ * @return 贴表情详情列表
+ */
+suspend fun NapCatBotApi.getMsgEmojiLike(messageId: Long): ArrayNode {
+    return apiRequest<ArrayNode>(
+        "get_msg_emoji_like",
+        mapOf("message_id" to messageId)
+    ) ?: Json.objectMapper().createArrayNode()
+}
+
+/**
+ * 发送合并转发消息
+ *
+ * @param groupId 群组id
+ * @param nodes 合并转发节点列表
+ * @return 发送结果（通常包含message_id等）
+ */
+suspend fun NapCatBotApi.sendGroupForwardMsg(
+    groupId: String = this.receiveMessage.source.id,
+    nodes: String
+): JsonNode? {
+    return apiRequest(
+        "send_forward_msg",
+        mapOf(
+            "group_id" to groupId,
+            "messages" to nodes
+        )
+    )
+}
+
+/**
+ * 获取语音消息详情
+ *
+ * @param file 语音file标识
+ * @param outFormat 输出格式（默认mp3）
+ * @return 语音详情（通常包含url/file等）
+ */
+suspend fun NapCatBotApi.getRecord(file: String, outFormat: String = "mp3"): JsonNode? {
+    return apiRequest("get_record", mapOf("file" to file, "out_format" to outFormat))
+}
+
+/**
+ * 获取图片消息详情
+ *
+ * @param file 图片file标识
+ * @return 图片详情（通常包含url/size等）
+ */
+suspend fun NapCatBotApi.getImage(file: String): JsonNode? {
+    return apiRequest("get_image", mapOf("file" to file))
+}
+
+
+/**
+ * 发送群AI语音
+ *
+ * @param groupId 群组id
+ * @param characterId 角色id
+ * @param text 文本内容
+ */
+suspend fun NapCatBotApi.sendGroupAiVoice(
+    groupId: String = this.receiveMessage.source.id,
+    characterId: String,
+    text: String
+) {
+    apiRequestUnit(
+        "send_group_ai_voice",
+        mapOf(
+            "group_id" to groupId,
+            "character_id" to characterId,
+            "text" to text
+        )
+    )
+}


### PR DESCRIPTION
### Motivation
- Preserve the existing NapCat adapter expand implementations as an archive while preparing to adapt to updated API/docs. 
- Isolate legacy code to avoid namespace clutter and make ongoing refactors safer.

### Description
- Move/duplicate NapCat expand implementations for account, file, group and message into a new package at `.../expand/bak` and update their package declarations to `com.blr19c.falowp.bot.adapter.nc.expand.bak`.
- Added archived files: `NapCatAccountExpand.kt`, `NapCatFileExpand.kt`, `NapCatGroupExpand.kt`, and `NapCatMessageExpand.kt` under `falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/bak` containing the previous API helper functions and data classes.
- Kept original public API signatures and helpers in the archived files so they can be referenced or restored if needed.
- Minor formatting cleanup applied to end-of-file newlines in some existing source files.

### Testing
- No automated tests were executed for this change (no test run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979becba8d88328ab18f4d765dff131)