### PR TITLE
Add NapCat API Docs expansions and response mappings

### DIFF
--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatAiExtraExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatAiExtraExpand.kt
@@ -1,0 +1,24 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+
+/**
+ * NapCatAiExtraExpand
+ */
+class NapCatAiExtraExpand
+
+/**
+ * 获取AI语音
+ */
+suspend fun NapCatBotApi.getAiRecord(groupId: Long, character: String, text: String): String {
+    return apiRequest("get_ai_record", mapOf("group_id" to groupId, "character" to character, "text" to text))
+}
+
+/**
+ * 发送群AI语音
+ */
+suspend fun NapCatBotApi.sendGroupAiRecord(groupId: Long, character: String, text: String) {
+    apiRequestUnit("send_group_ai_record", mapOf("group_id" to groupId, "character" to character, "text" to text))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatCoreApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatCoreApiExpand.kt
@@ -1,0 +1,40 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+
+/**
+ * NapCatCoreApiExpand
+ */
+class NapCatCoreApiExpand
+
+/**
+ * 发送私聊戳一戳
+ */
+suspend fun NapCatBotApi.friendPoke(userId: Long, targetId: Any? = null) {
+    apiRequestUnit("friend_poke", mapOf("user_id" to userId, "target_id" to targetId))
+}
+
+/**
+ * 发送群聊戳一戳
+ */
+suspend fun NapCatBotApi.groupPoke(groupId: Long, userId: Long) {
+    apiRequestUnit("group_poke", mapOf("group_id" to groupId, "user_id" to userId))
+}
+
+/**
+ * 发送戳一戳
+ */
+suspend fun NapCatBotApi.sendPoke(groupId: Long? = null, userId: Long, targetId: String? = null) {
+    apiRequestUnit("send_poke", mapOf("group_id" to groupId, "user_id" to userId, "target_id" to targetId))
+}
+
+/**
+ * 设置群待办
+ *
+ * 将指定消息设置为群待办
+ */
+suspend fun NapCatBotApi.setGroupTodo(groupId: String, messageId: String? = null, messageSeq: String? = null) {
+    apiRequestUnit("set_group_todo", mapOf("group_id" to groupId, "message_id" to messageId, "message_seq" to messageSeq))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatExpandApi.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatExpandApi.kt
@@ -5,9 +5,11 @@ import com.blr19c.falowp.bot.adapter.nc.web.NapCatWebSocket
 import com.blr19c.falowp.bot.system.adapterConfigProperty
 import com.blr19c.falowp.bot.system.json.Json
 import com.blr19c.falowp.bot.system.web.longTimeoutWebclient
+import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
+import tools.jackson.databind.JsonNode
 import java.util.*
 import kotlin.time.Duration.Companion.minutes
 
@@ -58,6 +60,14 @@ data class NapCatApiResult<T>(
 }
 
 /**
+ * NapCat 原始数据
+ */
+data class NapCatRawData @JsonCreator(mode = JsonCreator.Mode.DELEGATING) constructor(
+    val data: JsonNode
+)
+
+
+/**
  * NapCat WS
  */
 data class NapCatWsEcho(
@@ -104,5 +114,3 @@ internal suspend fun NapCatBotApi.apiRequestUnit(type: String, body: Any? = null
     if (result.success()) return
     throw IllegalStateException("NapCat-API-请求失败:${result.msg ?: ""}${result.wording ?: ""}")
 }
-
-

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatExtraApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatExtraApiExpand.kt
@@ -1,0 +1,115 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * GetAiCharactersDataItemCharactersItem
+ */
+data class GetAiCharactersDataItemCharactersItem(
+    @field:JsonProperty("character_id")
+    val characterId: String,
+    @field:JsonProperty("character_name")
+    val characterName: String,
+    @field:JsonProperty("preview_url")
+    val previewUrl: String
+)
+
+/**
+ * GetAiCharactersDataItem
+ */
+data class GetAiCharactersDataItem(
+    @field:JsonProperty("type")
+    val type: String,
+    @field:JsonProperty("characters")
+    val characters: List<GetAiCharactersDataItemCharactersItem>
+)
+
+/**
+ * GetClientkeyData
+ */
+data class GetClientkeyData(
+    @field:JsonProperty("clientkey")
+    val clientkey: String
+)
+
+/**
+ * NapCatExtraApiExpand
+ */
+class NapCatExtraApiExpand
+
+/**
+ * .OCR 图片识别
+ *
+ * 仅 Windows 可用
+ */
+suspend fun NapCatBotApi..ocrImage(image: String) {
+    apiRequestUnit(".ocr_image", mapOf("image" to image))
+}
+
+/**
+ * 创建收藏
+ */
+suspend fun NapCatBotApi.createCollection(rawData: String, brief: String) {
+    apiRequestUnit("create_collection", mapOf("rawData" to rawData, "brief" to brief))
+}
+
+/**
+ * 获取AI语音人物
+ */
+suspend fun NapCatBotApi.getAiCharacters(groupId: Long, chatType: Long? = null): List<GetAiCharactersDataItem> {
+    return apiRequest("get_ai_characters", mapOf("group_id" to groupId, "chat_type" to chatType))
+}
+
+/**
+ * 获取clientkey
+ */
+suspend fun NapCatBotApi.getClientkey(): GetClientkeyData {
+    return apiRequest("get_clientkey")
+}
+
+/**
+ * OCR 图片识别
+ *
+ * 仅 Windows 可用
+ */
+suspend fun NapCatBotApi.ocrImage(image: String) {
+    apiRequestUnit("ocr_image", mapOf("image" to image))
+}
+
+/**
+ * 批量踢出群成员
+ */
+suspend fun NapCatBotApi.setGroupKickMembers(groupId: Long, userId: List<Long>, rejectAddRequest: Boolean? = null) {
+    apiRequestUnit("set_group_kick_members", mapOf("group_id" to groupId, "user_id" to userId, "reject_add_request" to rejectAddRequest))
+}
+
+/**
+ * 设置群头衔
+ */
+suspend fun NapCatBotApi.setGroupSpecialTitle(groupId: Long, userId: Long, specialTitle: String? = null) {
+    apiRequestUnit("set_group_special_title", mapOf("group_id" to groupId, "user_id" to userId, "special_title" to specialTitle))
+}
+
+/**
+ * 设置头像
+ */
+suspend fun NapCatBotApi.setQqAvatar(file: String) {
+    apiRequestUnit("set_qq_avatar", mapOf("file" to file))
+}
+
+/**
+ * 设置个性签名
+ */
+suspend fun NapCatBotApi.setSelfLongnick(longNick: String) {
+    apiRequestUnit("set_self_longnick", mapOf("longNick" to longNick))
+}
+
+/**
+ * 英译中
+ */
+suspend fun NapCatBotApi.translateEn2zh(words: List<String>) {
+    apiRequestUnit("translate_en2zh", mapOf("words" to words))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatFileApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatFileApiExpand.kt
@@ -1,0 +1,110 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * GetFileData
+ */
+data class GetFileData(
+    @field:JsonProperty("file")
+    val file: String,
+    @field:JsonProperty("url")
+    val url: String,
+    @field:JsonProperty("file_size")
+    val fileSize: String,
+    @field:JsonProperty("file_name")
+    val fileName: String,
+    @field:JsonProperty("base64")
+    val base64: String
+)
+
+/**
+ * GetGroupFileUrlData
+ */
+data class GetGroupFileUrlData(
+    @field:JsonProperty("url")
+    val url: String
+)
+
+/**
+ * GetImageData
+ */
+data class GetImageData(
+    @field:JsonProperty("file")
+    val file: String,
+    @field:JsonProperty("url")
+    val url: String,
+    @field:JsonProperty("file_size")
+    val fileSize: String,
+    @field:JsonProperty("file_name")
+    val fileName: String,
+    @field:JsonProperty("base64")
+    val base64: String
+)
+
+/**
+ * GetPrivateFileUrlData
+ */
+data class GetPrivateFileUrlData(
+    @field:JsonProperty("url")
+    val url: String
+)
+
+/**
+ * GetRecordData
+ */
+data class GetRecordData(
+    @field:JsonProperty("file")
+    val file: String,
+    @field:JsonProperty("url")
+    val url: String,
+    @field:JsonProperty("file_size")
+    val fileSize: String,
+    @field:JsonProperty("file_name")
+    val fileName: String,
+    @field:JsonProperty("base64")
+    val base64: String
+)
+
+/**
+ * NapCatFileApiExpand
+ */
+class NapCatFileApiExpand
+
+/**
+ * 获取文件信息
+ */
+suspend fun NapCatBotApi.getFile(fileId: String? = null, file: String? = null): GetFileData {
+    return apiRequest("get_file", mapOf("file_id" to fileId, "file" to file))
+}
+
+/**
+ * 获取群文件链接
+ */
+suspend fun NapCatBotApi.getGroupFileUrl(groupId: Long, fileId: String): GetGroupFileUrlData {
+    return apiRequest("get_group_file_url", mapOf("group_id" to groupId, "file_id" to fileId))
+}
+
+/**
+ * 获取图片消息详情
+ */
+suspend fun NapCatBotApi.getImage(fileId: String? = null, file: String? = null): GetImageData {
+    return apiRequest("get_image", mapOf("file_id" to fileId, "file" to file))
+}
+
+/**
+ * 获取私聊文件链接
+ */
+suspend fun NapCatBotApi.getPrivateFileUrl(fileId: String): GetPrivateFileUrlData {
+    return apiRequest("get_private_file_url", mapOf("file_id" to fileId))
+}
+
+/**
+ * 获取语音消息详情
+ */
+suspend fun NapCatBotApi.getRecord(file: String? = null, fileId: String? = null, outFormat: String): GetRecordData {
+    return apiRequest("get_record", mapOf("file" to file, "file_id" to fileId, "out_format" to outFormat))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatFileExtraExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatFileExtraExpand.kt
@@ -1,0 +1,138 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * GetFilesetIdData
+ */
+data class GetFilesetIdData(
+    @field:JsonProperty("fileset_id")
+    val filesetId: String
+)
+
+/**
+ * NapCatFileExtraExpand
+ */
+class NapCatFileExtraExpand
+
+/**
+ * 取消在线文件
+ */
+suspend fun NapCatBotApi.cancelOnlineFile(userId: String, msgId: String) {
+    apiRequestUnit("cancel_online_file", mapOf("user_id" to userId, "msg_id" to msgId))
+}
+
+/**
+ * 创建闪照任务
+ */
+suspend fun NapCatBotApi.createFlashTask(files: List<String>, name: String? = null, thumbPath: String? = null) {
+    apiRequestUnit("create_flash_task", mapOf("files" to files, "name" to name, "thumb_path" to thumbPath))
+}
+
+/**
+ * 下载文件集
+ */
+suspend fun NapCatBotApi.downloadFileset(filesetId: String): String {
+    return apiRequest("download_fileset", mapOf("fileset_id" to filesetId))
+}
+
+/**
+ * 获取文件集 ID
+ */
+suspend fun NapCatBotApi.getFilesetId(shareCode: String): GetFilesetIdData {
+    return apiRequest("get_fileset_id", mapOf("share_code" to shareCode))
+}
+
+/**
+ * 获取文件集信息
+ */
+suspend fun NapCatBotApi.getFilesetInfo(filesetId: String): String {
+    return apiRequest("get_fileset_info", mapOf("fileset_id" to filesetId))
+}
+
+/**
+ * 获取闪照文件列表
+ */
+suspend fun NapCatBotApi.getFlashFileList(filesetId: String): String {
+    return apiRequest("get_flash_file_list", mapOf("fileset_id" to filesetId))
+}
+
+/**
+ * 获取闪照文件链接
+ */
+suspend fun NapCatBotApi.getFlashFileUrl(filesetId: String, fileName: String? = null, fileIndex: Long? = null): String {
+    return apiRequest("get_flash_file_url", mapOf("fileset_id" to filesetId, "file_name" to fileName, "file_index" to fileIndex))
+}
+
+/**
+ * 获取在线文件消息
+ */
+suspend fun NapCatBotApi.getOnlineFileMsg(userId: String): String {
+    return apiRequest("get_online_file_msg", mapOf("user_id" to userId))
+}
+
+/**
+ * 获取文件分享链接
+ */
+suspend fun NapCatBotApi.getShareLink(filesetId: String): String {
+    return apiRequest("get_share_link", mapOf("fileset_id" to filesetId))
+}
+
+/**
+ * 移动群文件
+ */
+suspend fun NapCatBotApi.moveGroupFile(groupId: Long, fileId: String, currentParentDirectory: String, targetParentDirectory: String) {
+    apiRequestUnit("move_group_file", mapOf("group_id" to groupId, "file_id" to fileId, "current_parent_directory" to currentParentDirectory, "target_parent_directory" to targetParentDirectory))
+}
+
+/**
+ * 接收在线文件
+ */
+suspend fun NapCatBotApi.receiveOnlineFile(userId: String, msgId: String, elementId: String) {
+    apiRequestUnit("receive_online_file", mapOf("user_id" to userId, "msg_id" to msgId, "element_id" to elementId))
+}
+
+/**
+ * 拒绝在线文件
+ */
+suspend fun NapCatBotApi.refuseOnlineFile(userId: String, msgId: String, elementId: String) {
+    apiRequestUnit("refuse_online_file", mapOf("user_id" to userId, "msg_id" to msgId, "element_id" to elementId))
+}
+
+/**
+ * 重命名群文件
+ */
+suspend fun NapCatBotApi.renameGroupFile(groupId: Long, fileId: String, currentParentDirectory: String, newName: String) {
+    apiRequestUnit("rename_group_file", mapOf("group_id" to groupId, "file_id" to fileId, "current_parent_directory" to currentParentDirectory, "new_name" to newName))
+}
+
+/**
+ * 发送闪照消息
+ */
+suspend fun NapCatBotApi.sendFlashMsg(filesetId: String, userId: String? = null, groupId: String? = null) {
+    apiRequestUnit("send_flash_msg", mapOf("fileset_id" to filesetId, "user_id" to userId, "group_id" to groupId))
+}
+
+/**
+ * 发送在线文件
+ */
+suspend fun NapCatBotApi.sendOnlineFile(userId: String, filePath: String, fileName: String? = null) {
+    apiRequestUnit("send_online_file", mapOf("user_id" to userId, "file_path" to filePath, "file_name" to fileName))
+}
+
+/**
+ * 发送在线文件夹
+ */
+suspend fun NapCatBotApi.sendOnlineFolder(userId: String, folderPath: String, folderName: String? = null) {
+    apiRequestUnit("send_online_folder", mapOf("user_id" to userId, "folder_path" to folderPath, "folder_name" to folderName))
+}
+
+/**
+ * 转存为永久文件
+ */
+suspend fun NapCatBotApi.transGroupFile(groupId: Long, fileId: String) {
+    apiRequestUnit("trans_group_file", mapOf("group_id" to groupId, "file_id" to fileId))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatGoCqHttpExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatGoCqHttpExpand.kt
@@ -1,0 +1,365 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * GetModelShowDataItemVariants
+ */
+data class GetModelShowDataItemVariants(
+    @field:JsonProperty("model_show")
+    val modelShow: String,
+    @field:JsonProperty("need_pay")
+    val needPay: Boolean
+)
+
+/**
+ * GetModelShowDataItem
+ */
+data class GetModelShowDataItem(
+    @field:JsonProperty("variants")
+    val variants: GetModelShowDataItemVariants
+)
+
+/**
+ * DownloadFileData
+ */
+data class DownloadFileData(
+    @field:JsonProperty("file")
+    val file: String
+)
+
+/**
+ * GetForwardMsgData
+ */
+data class GetForwardMsgData(
+    @field:JsonProperty("messages")
+    val messages: List<Any>
+)
+
+/**
+ * GetFriendMsgHistoryData
+ */
+data class GetFriendMsgHistoryData(
+    @field:JsonProperty("messages")
+    val messages: List<Any>
+)
+
+/**
+ * GetGroupAtAllRemainData
+ */
+data class GetGroupAtAllRemainData(
+    @field:JsonProperty("can_at_all")
+    val canAtAll: Boolean,
+    @field:JsonProperty("remain_at_all_count_for_group")
+    val remainAtAllCountForGroup: Long,
+    @field:JsonProperty("remain_at_all_count_for_uin")
+    val remainAtAllCountForUin: Long
+)
+
+/**
+ * GetGroupFileSystemInfoData
+ */
+data class GetGroupFileSystemInfoData(
+    @field:JsonProperty("file_count")
+    val fileCount: Long,
+    @field:JsonProperty("limit_count")
+    val limitCount: Long,
+    @field:JsonProperty("used_space")
+    val usedSpace: Long,
+    @field:JsonProperty("total_space")
+    val totalSpace: Long
+)
+
+/**
+ * GetGroupFilesByFolderData
+ */
+data class GetGroupFilesByFolderData(
+    @field:JsonProperty("files")
+    val files: List<Any>,
+    @field:JsonProperty("folders")
+    val folders: List<Any>?
+)
+
+/**
+ * GetGroupHonorInfoData
+ */
+data class GetGroupHonorInfoData(
+    @field:JsonProperty("group_id")
+    val groupId: String,
+    @field:JsonProperty("current_talkative")
+    val currentTalkative: Any,
+    @field:JsonProperty("talkative_list")
+    val talkativeList: List<Any>,
+    @field:JsonProperty("performer_list")
+    val performerList: List<Any>,
+    @field:JsonProperty("legend_list")
+    val legendList: List<Any>,
+    @field:JsonProperty("emotion_list")
+    val emotionList: List<Any>,
+    @field:JsonProperty("strong_newbie_list")
+    val strongNewbieList: List<Any>
+)
+
+/**
+ * GetGroupMsgHistoryData
+ */
+data class GetGroupMsgHistoryData(
+    @field:JsonProperty("messages")
+    val messages: List<Any>
+)
+
+/**
+ * GetGroupRootFilesData
+ */
+data class GetGroupRootFilesData(
+    @field:JsonProperty("files")
+    val files: List<Any>,
+    @field:JsonProperty("folders")
+    val folders: List<Any>
+)
+
+/**
+ * GetStrangerInfoData
+ */
+data class GetStrangerInfoData(
+    @field:JsonProperty("user_id")
+    val userId: Long,
+    @field:JsonProperty("uid")
+    val uid: String,
+    @field:JsonProperty("uin")
+    val uin: String,
+    @field:JsonProperty("nickname")
+    val nickname: String,
+    @field:JsonProperty("age")
+    val age: Long,
+    @field:JsonProperty("qid")
+    val qid: String,
+    @field:JsonProperty("qqLevel")
+    val qqLevel: Long,
+    @field:JsonProperty("sex")
+    val sex: String,
+    @field:JsonProperty("long_nick")
+    val longNick: String,
+    @field:JsonProperty("reg_time")
+    val regTime: Long,
+    @field:JsonProperty("is_vip")
+    val isVip: Boolean,
+    @field:JsonProperty("is_years_vip")
+    val isYearsVip: Boolean,
+    @field:JsonProperty("vip_level")
+    val vipLevel: Long,
+    @field:JsonProperty("remark")
+    val remark: String,
+    @field:JsonProperty("status")
+    val status: Long,
+    @field:JsonProperty("login_days")
+    val loginDays: Long
+)
+
+/**
+ * NapCatGoCqHttpExpand
+ */
+class NapCatGoCqHttpExpand
+
+/**
+ * .对事件执行快速操作
+ *
+ * 相当于http的快速操作
+ */
+suspend fun NapCatBotApi..handleQuickOperation(context: NapCatRawData, operation: NapCatRawData) {
+    apiRequestUnit(".handle_quick_operation", mapOf("context" to context, "operation" to operation))
+}
+
+/**
+ * _获取在线机型
+ */
+suspend fun NapCatBotApi.getModelShow(model: String): List<GetModelShowDataItem> {
+    return apiRequest("_get_model_show", mapOf("model" to model))
+}
+
+/**
+ * _发送群公告
+ */
+suspend fun NapCatBotApi.sendGroupNotice(groupId: Long, content: String, image: String? = null, pinned: Any? = null, type: Any? = null, confirmRequired: Any? = null, isShowEditCard: Any? = null, tipWindowType: Any? = null) {
+    apiRequestUnit("_send_group_notice", mapOf("group_id" to groupId, "content" to content, "image" to image, "pinned" to pinned, "type" to type, "confirm_required" to confirmRequired, "is_show_edit_card" to isShowEditCard, "tip_window_type" to tipWindowType))
+}
+
+/**
+ * _设置在线机型
+ */
+suspend fun NapCatBotApi.setModelShow() {
+    apiRequestUnit("_set_model_show")
+}
+
+/**
+ * 检查链接安全性
+ */
+suspend fun NapCatBotApi.checkUrlSafely(): NapCatRawData {
+    return apiRequest("check_url_safely")
+}
+
+/**
+ * 创建群文件文件夹
+ */
+suspend fun NapCatBotApi.createGroupFileFolder(groupId: Long, folderName: String) {
+    apiRequestUnit("create_group_file_folder", mapOf("group_id" to groupId, "folder_name" to folderName))
+}
+
+/**
+ * 删除好友
+ */
+suspend fun NapCatBotApi.deleteFriend(userId: Long? = null, friendId: Long? = null, tempBlock: Boolean, tempBothDel: Boolean) {
+    apiRequestUnit("delete_friend", mapOf("user_id" to userId, "friend_id" to friendId, "temp_block" to tempBlock, "temp_both_del" to tempBothDel))
+}
+
+/**
+ * 删除群文件
+ */
+suspend fun NapCatBotApi.deleteGroupFile(groupId: Long, fileId: String) {
+    apiRequestUnit("delete_group_file", mapOf("group_id" to groupId, "file_id" to fileId))
+}
+
+/**
+ * 删除群文件夹
+ */
+suspend fun NapCatBotApi.deleteGroupFolder(groupId: Long, folderId: String) {
+    apiRequestUnit("delete_group_folder", mapOf("group_id" to groupId, "folder_id" to folderId))
+}
+
+/**
+ * 下载文件到缓存目录
+ */
+suspend fun NapCatBotApi.downloadFile(url: String? = null, base64: String? = null, name: String? = null, headers: String? = null): DownloadFileData {
+    return apiRequest("download_file", mapOf("url" to url, "base64" to base64, "name" to name, "headers" to headers))
+}
+
+/**
+ * 获取合并转发消息
+ */
+suspend fun NapCatBotApi.getForwardMsg(messageId: String): GetForwardMsgData {
+    return apiRequest("get_forward_msg", mapOf("message_id" to messageId))
+}
+
+/**
+ * 获取好友历史消息
+ */
+suspend fun NapCatBotApi.getFriendMsgHistory(userId: Long, messageSeq: Long? = null, count: Long? = null, reverseOrder: Boolean? = null): GetFriendMsgHistoryData {
+    return apiRequest("get_friend_msg_history", mapOf("user_id" to userId, "message_seq" to messageSeq, "count" to count, "reverseOrder" to reverseOrder))
+}
+
+/**
+ * 获取群 @全体成员 剩余次数
+ */
+suspend fun NapCatBotApi.getGroupAtAllRemain(groupId: Long): GetGroupAtAllRemainData {
+    return apiRequest("get_group_at_all_remain", mapOf("group_id" to groupId))
+}
+
+/**
+ * 获取群文件系统信息
+ */
+suspend fun NapCatBotApi.getGroupFileSystemInfo(groupId: Long): GetGroupFileSystemInfoData {
+    return apiRequest("get_group_file_system_info", mapOf("group_id" to groupId))
+}
+
+/**
+ * 获取群子目录文件列表
+ */
+suspend fun NapCatBotApi.getGroupFilesByFolder(groupId: Long, folderId: String? = null, folder: String? = null, fileCount: Long? = null): GetGroupFilesByFolderData {
+    return apiRequest("get_group_files_by_folder", mapOf("group_id" to groupId, "folder_id" to folderId, "folder" to folder, "file_count" to fileCount))
+}
+
+/**
+ * 获取群荣誉
+ *
+ * |  type                   |         类型                    |
+|  ----------------- | ------------------------ |
+| all                       |  所有（默认）             |
+| talkative              | 群聊之火                     |
+| performer           | 群聊炽焰                     |
+| legend                | 龙王                             |
+| strong_newbie   | 冒尖小春笋（R.I.P）     |
+| emotion              | 快乐源泉                      |
+ */
+suspend fun NapCatBotApi.getGroupHonorInfo(groupId: Long, type: String? = null): GetGroupHonorInfoData {
+    return apiRequest("get_group_honor_info", mapOf("group_id" to groupId, "type" to type))
+}
+
+/**
+ * 获取群历史消息
+ */
+suspend fun NapCatBotApi.getGroupMsgHistory(groupId: Long, messageSeq: Long? = null, count: Long? = null, reverseOrder: Boolean? = null): GetGroupMsgHistoryData {
+    return apiRequest("get_group_msg_history", mapOf("group_id" to groupId, "message_seq" to messageSeq, "count" to count, "reverseOrder" to reverseOrder))
+}
+
+/**
+ * 获取群根目录文件列表
+ */
+suspend fun NapCatBotApi.getGroupRootFiles(groupId: Long, fileCount: Long? = null): GetGroupRootFilesData {
+    return apiRequest("get_group_root_files", mapOf("group_id" to groupId, "file_count" to fileCount))
+}
+
+/**
+ * 获取当前账号在线客户端列表
+ */
+suspend fun NapCatBotApi.getOnlineClients(): List<String> {
+    return apiRequest("get_online_clients")
+}
+
+/**
+ * 获取账号信息
+ */
+suspend fun NapCatBotApi.getStrangerInfo(userId: Long): GetStrangerInfoData {
+    return apiRequest("get_stranger_info", mapOf("user_id" to userId))
+}
+
+/**
+ * 发送合并转发消息
+ */
+suspend fun NapCatBotApi.sendForwardMsg(groupId: Long? = null, userId: Long? = null, messages: List<Any>, news: List<NewsItem>, prompt: String, summary: String, source: String) {
+    apiRequestUnit("send_forward_msg", mapOf("group_id" to groupId, "user_id" to userId, "messages" to messages, "news" to news, "prompt" to prompt, "summary" to summary, "source" to source))
+}
+
+/**
+ * 发送群合并转发消息
+ */
+suspend fun NapCatBotApi.sendGroupForwardMsg(groupId: Long, messages: List<Any>, news: List<NewsItem>, prompt: String, summary: String, source: String) {
+    apiRequestUnit("send_group_forward_msg", mapOf("group_id" to groupId, "messages" to messages, "news" to news, "prompt" to prompt, "summary" to summary, "source" to source))
+}
+
+/**
+ * 发送私聊合并转发消息
+ */
+suspend fun NapCatBotApi.sendPrivateForwardMsg(userId: Long, messages: List<MessagesItem>) {
+    apiRequestUnit("send_private_forward_msg", mapOf("user_id" to userId, "messages" to messages))
+}
+
+/**
+ * 设置群头像
+ */
+suspend fun NapCatBotApi.setGroupPortrait(groupId: Long, file: String) {
+    apiRequestUnit("set_group_portrait", mapOf("group_id" to groupId, "file" to file))
+}
+
+/**
+ * 设置账号信息
+ */
+suspend fun NapCatBotApi.setQqProfile(nickname: String, personalNote: String? = null, sex: String? = null) {
+    apiRequestUnit("set_qq_profile", mapOf("nickname" to nickname, "personal_note" to personalNote, "sex" to sex))
+}
+
+/**
+ * 上传群文件
+ */
+suspend fun NapCatBotApi.uploadGroupFile(groupId: Long, file: String, name: String, folder: String? = null, folderId: String? = null) {
+    apiRequestUnit("upload_group_file", mapOf("group_id" to groupId, "file" to file, "name" to name, "folder" to folder, "folder_id" to folderId))
+}
+
+/**
+ * 上传私聊文件
+ */
+suspend fun NapCatBotApi.uploadPrivateFile(userId: Long, file: String, name: String) {
+    apiRequestUnit("upload_private_file", mapOf("user_id" to userId, "file" to file, "name" to name))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatGroupApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatGroupApiExpand.kt
@@ -1,0 +1,342 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * GetGroupNoticeDataItemMessageItem
+ */
+data class GetGroupNoticeDataItemMessageItem(
+    @field:JsonProperty("id")
+    val id: String,
+    @field:JsonProperty("height")
+    val height: String,
+    @field:JsonProperty("width")
+    val width: String
+)
+
+/**
+ * GetGroupNoticeDataItem
+ */
+data class GetGroupNoticeDataItem(
+    @field:JsonProperty("notice_id")
+    val noticeId: String,
+    @field:JsonProperty("sender_id")
+    val senderId: Long,
+    @field:JsonProperty("publish_time")
+    val publishTime: Long,
+    @field:JsonProperty("message")
+    val message: List<GetGroupNoticeDataItemMessageItem>
+)
+
+/**
+ * GetEssenceMsgListDataItem
+ */
+data class GetEssenceMsgListDataItem(
+    @field:JsonProperty("msg_seq")
+    val msgSeq: Long,
+    @field:JsonProperty("msg_random")
+    val msgRandom: Long,
+    @field:JsonProperty("sender_id")
+    val senderId: Long,
+    @field:JsonProperty("sender_nick")
+    val senderNick: String,
+    @field:JsonProperty("operator_id")
+    val operatorId: Long,
+    @field:JsonProperty("operator_nick")
+    val operatorNick: String,
+    @field:JsonProperty("message_id")
+    val messageId: Long,
+    @field:JsonProperty("operator_time")
+    val operatorTime: Long,
+    @field:JsonProperty("content")
+    val content: List<Any>
+)
+
+/**
+ * GetGroupDetailInfoData
+ */
+data class GetGroupDetailInfoData(
+    @field:JsonProperty("group_all_shut")
+    val groupAllShut: Long,
+    @field:JsonProperty("group_remark")
+    val groupRemark: String,
+    @field:JsonProperty("group_id")
+    val groupId: Long,
+    @field:JsonProperty("group_name")
+    val groupName: String,
+    @field:JsonProperty("member_count")
+    val memberCount: Long,
+    @field:JsonProperty("max_member_count")
+    val maxMemberCount: Long
+)
+
+/**
+ * GetGroupIgnoreAddRequestDataItem
+ */
+data class GetGroupIgnoreAddRequestDataItem(
+    @field:JsonProperty("request_id")
+    val requestId: Long,
+    @field:JsonProperty("invitor_uin")
+    val invitorUin: Long,
+    @field:JsonProperty("invitor_nick")
+    val invitorNick: String,
+    @field:JsonProperty("group_id")
+    val groupId: Long,
+    @field:JsonProperty("message")
+    val message: String,
+    @field:JsonProperty("group_name")
+    val groupName: String,
+    @field:JsonProperty("checked")
+    val checked: Boolean,
+    @field:JsonProperty("actor")
+    val actor: Long,
+    @field:JsonProperty("requester_nick")
+    val requesterNick: String
+)
+
+/**
+ * GetGroupIgnoredNotifiesData
+ */
+data class GetGroupIgnoredNotifiesData(
+    @field:JsonProperty("InvitedRequest")
+    val InvitedRequest: List<Any>,
+    @field:JsonProperty("join_requests")
+    val joinRequests: List<Any>
+)
+
+/**
+ * GetGroupShutListDataItem
+ */
+data class GetGroupShutListDataItem(
+    @field:JsonProperty("uid")
+    val uid: String,
+    @field:JsonProperty("qid")
+    val qid: String,
+    @field:JsonProperty("uin")
+    val uin: String,
+    @field:JsonProperty("nick")
+    val nick: String,
+    @field:JsonProperty("remark")
+    val remark: String,
+    @field:JsonProperty("cardType")
+    val cardType: Long,
+    @field:JsonProperty("cardName")
+    val cardName: String,
+    @field:JsonProperty("role")
+    val role: Long,
+    @field:JsonProperty("avatarPath")
+    val avatarPath: String,
+    @field:JsonProperty("shutUpTime")
+    val shutUpTime: Long,
+    @field:JsonProperty("isDelete")
+    val isDelete: Boolean,
+    @field:JsonProperty("isSpecialConcerned")
+    val isSpecialConcerned: Boolean,
+    @field:JsonProperty("isSpecialShield")
+    val isSpecialShield: Boolean,
+    @field:JsonProperty("isRobot")
+    val isRobot: Boolean,
+    @field:JsonProperty("groupHonor")
+    val groupHonor: NapCatRawData,
+    @field:JsonProperty("memberRealLevel")
+    val memberRealLevel: Long,
+    @field:JsonProperty("memberLevel")
+    val memberLevel: Long,
+    @field:JsonProperty("globalGroupLevel")
+    val globalGroupLevel: Long,
+    @field:JsonProperty("globalGroupPoint")
+    val globalGroupPoint: Long,
+    @field:JsonProperty("memberTitleId")
+    val memberTitleId: Long,
+    @field:JsonProperty("memberSpecialTitle")
+    val memberSpecialTitle: String,
+    @field:JsonProperty("specialTitleExpireTime")
+    val specialTitleExpireTime: String,
+    @field:JsonProperty("userShowFlag")
+    val userShowFlag: Long,
+    @field:JsonProperty("userShowFlagNew")
+    val userShowFlagNew: Long,
+    @field:JsonProperty("richFlag")
+    val richFlag: Long,
+    @field:JsonProperty("mssVipType")
+    val mssVipType: Long,
+    @field:JsonProperty("bigClubLevel")
+    val bigClubLevel: Long,
+    @field:JsonProperty("bigClubFlag")
+    val bigClubFlag: Long,
+    @field:JsonProperty("autoRemark")
+    val autoRemark: String,
+    @field:JsonProperty("creditLevel")
+    val creditLevel: Long,
+    @field:JsonProperty("joinTime")
+    val joinTime: Long,
+    @field:JsonProperty("lastSpeakTime")
+    val lastSpeakTime: Long,
+    @field:JsonProperty("memberFlag")
+    val memberFlag: Long,
+    @field:JsonProperty("memberFlagExt")
+    val memberFlagExt: Long,
+    @field:JsonProperty("memberMobileFlag")
+    val memberMobileFlag: Long,
+    @field:JsonProperty("memberFlagExt2")
+    val memberFlagExt2: Long,
+    @field:JsonProperty("isSpecialShielded")
+    val isSpecialShielded: Boolean,
+    @field:JsonProperty("cardNameId")
+    val cardNameId: Long
+)
+
+/**
+ * NapCatGroupApiExpand
+ */
+class NapCatGroupApiExpand
+
+/**
+ * _删除群公告
+ */
+suspend fun NapCatBotApi.delGroupNotice(groupId: Long, noticeId: String) {
+    apiRequestUnit("_del_group_notice", mapOf("group_id" to groupId, "notice_id" to noticeId))
+}
+
+/**
+ * _获取群公告
+ */
+suspend fun NapCatBotApi.getGroupNotice(groupId: Long): List<GetGroupNoticeDataItem> {
+    return apiRequest("_get_group_notice", mapOf("group_id" to groupId))
+}
+
+/**
+ * 删除群精华消息
+ */
+suspend fun NapCatBotApi.deleteEssenceMsg(messageId: Long) {
+    apiRequestUnit("delete_essence_msg", mapOf("message_id" to messageId))
+}
+
+/**
+ * 获取群精华消息
+ */
+suspend fun NapCatBotApi.getEssenceMsgList(groupId: Long): List<GetEssenceMsgListDataItem> {
+    return apiRequest("get_essence_msg_list", mapOf("group_id" to groupId))
+}
+
+/**
+ * 获取群详细信息
+ */
+suspend fun NapCatBotApi.getGroupDetailInfo(groupId: Long): GetGroupDetailInfoData {
+    return apiRequest("get_group_detail_info", mapOf("group_id" to groupId))
+}
+
+/**
+ * 获取被过滤的加群请求
+ */
+suspend fun NapCatBotApi.getGroupIgnoreAddRequest(): List<GetGroupIgnoreAddRequestDataItem> {
+    return apiRequest("get_group_ignore_add_request")
+}
+
+/**
+ * 获取群过滤系统消息
+ */
+suspend fun NapCatBotApi.getGroupIgnoredNotifies(): GetGroupIgnoredNotifiesData {
+    return apiRequest("get_group_ignored_notifies")
+}
+
+/**
+ * 获取群信息
+ */
+suspend fun NapCatBotApi.getGroupInfo(groupId: Long): NapCatRawData {
+    return apiRequest("get_group_info", mapOf("group_id" to groupId))
+}
+
+/**
+ * 获取群列表
+ */
+suspend fun NapCatBotApi.getGroupList(noCache: Boolean): List<NapCatRawData> {
+    return apiRequest("get_group_list", mapOf("no_cache" to noCache))
+}
+
+/**
+ * 获取群成员信息
+ */
+suspend fun NapCatBotApi.getGroupMemberInfo(groupId: Long, userId: Long, noCache: Boolean): NapCatRawData {
+    return apiRequest("get_group_member_info", mapOf("group_id" to groupId, "user_id" to userId, "no_cache" to noCache))
+}
+
+/**
+ * 获取群成员列表
+ */
+suspend fun NapCatBotApi.getGroupMemberList(groupId: Long, noCache: Boolean? = null): List<NapCatRawData> {
+    return apiRequest("get_group_member_list", mapOf("group_id" to groupId, "no_cache" to noCache))
+}
+
+/**
+ * 获取群禁言列表
+ */
+suspend fun NapCatBotApi.getGroupShutList(groupId: Long): List<GetGroupShutListDataItem> {
+    return apiRequest("get_group_shut_list", mapOf("group_id" to groupId))
+}
+
+/**
+ * 设置群精华消息
+ */
+suspend fun NapCatBotApi.setEssenceMsg(messageId: Long) {
+    apiRequestUnit("set_essence_msg", mapOf("message_id" to messageId))
+}
+
+/**
+ * 处理加群请求
+ */
+suspend fun NapCatBotApi.setGroupAddRequest(flag: String, approve: Boolean, reason: String? = null) {
+    apiRequestUnit("set_group_add_request", mapOf("flag" to flag, "approve" to approve, "reason" to reason))
+}
+
+/**
+ * 设置群管理
+ */
+suspend fun NapCatBotApi.setGroupAdmin(groupId: Long, userId: Long, enable: Boolean) {
+    apiRequestUnit("set_group_admin", mapOf("group_id" to groupId, "user_id" to userId, "enable" to enable))
+}
+
+/**
+ * 群禁言
+ */
+suspend fun NapCatBotApi.setGroupBan(groupId: Long, userId: Long, duration: Long) {
+    apiRequestUnit("set_group_ban", mapOf("group_id" to groupId, "user_id" to userId, "duration" to duration))
+}
+
+/**
+ * 设置群成员名片
+ */
+suspend fun NapCatBotApi.setGroupCard(groupId: Long, userId: Long, card: String? = null) {
+    apiRequestUnit("set_group_card", mapOf("group_id" to groupId, "user_id" to userId, "card" to card))
+}
+
+/**
+ * 群踢人
+ */
+suspend fun NapCatBotApi.setGroupKick(groupId: Long, userId: Long, rejectAddRequest: Boolean? = null) {
+    apiRequestUnit("set_group_kick", mapOf("group_id" to groupId, "user_id" to userId, "reject_add_request" to rejectAddRequest))
+}
+
+/**
+ * 退群
+ */
+suspend fun NapCatBotApi.setGroupLeave(groupId: Long, isDismiss: Boolean? = null) {
+    apiRequestUnit("set_group_leave", mapOf("group_id" to groupId, "is_dismiss" to isDismiss))
+}
+
+/**
+ * 设置群名
+ */
+suspend fun NapCatBotApi.setGroupName(groupId: Long, groupName: String) {
+    apiRequestUnit("set_group_name", mapOf("group_id" to groupId, "group_name" to groupName))
+}
+
+/**
+ * 全体禁言
+ */
+suspend fun NapCatBotApi.setGroupWholeBan(groupId: Long, enable: Boolean) {
+    apiRequestUnit("set_group_whole_ban", mapOf("group_id" to groupId, "enable" to enable))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatGroupExtraExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatGroupExtraExpand.kt
@@ -1,0 +1,230 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * GetGroupInfoExDataExtInfoGroupOwnerId
+ */
+data class GetGroupInfoExDataExtInfoGroupOwnerId(
+    @field:JsonProperty("memberUin")
+    val memberUin: String,
+    @field:JsonProperty("memberUid")
+    val memberUid: String,
+    @field:JsonProperty("memberQid")
+    val memberQid: String
+)
+
+/**
+ * GetGroupInfoExDataExtInfoGroupBindGuildIds
+ */
+data class GetGroupInfoExDataExtInfoGroupBindGuildIds(
+    @field:JsonProperty("guildIds")
+    val guildIds: List<String>
+)
+
+/**
+ * GetGroupInfoExDataExtInfoGroupExtFlameData
+ */
+data class GetGroupInfoExDataExtInfoGroupExtFlameData(
+    @field:JsonProperty("switchState")
+    val switchState: Int,
+    @field:JsonProperty("state")
+    val state: Int,
+    @field:JsonProperty("dayNums")
+    val dayNums: List<String>,
+    @field:JsonProperty("version")
+    val version: Int,
+    @field:JsonProperty("updateTime")
+    val updateTime: String,
+    @field:JsonProperty("isDisplayDayNum")
+    val isDisplayDayNum: Boolean
+)
+
+/**
+ * GetGroupInfoExDataExtInfoGroupExcludeGuildIds
+ */
+data class GetGroupInfoExDataExtInfoGroupExcludeGuildIds(
+    @field:JsonProperty("guildIds")
+    val guildIds: List<String>
+)
+
+/**
+ * GetGroupInfoExDataExtInfo
+ */
+data class GetGroupInfoExDataExtInfo(
+    @field:JsonProperty("groupInfoExtSeq")
+    val groupInfoExtSeq: Long,
+    @field:JsonProperty("reserve")
+    val reserve: Long,
+    @field:JsonProperty("luckyWordId")
+    val luckyWordId: String,
+    @field:JsonProperty("lightCharNum")
+    val lightCharNum: Long,
+    @field:JsonProperty("luckyWord")
+    val luckyWord: String,
+    @field:JsonProperty("starId")
+    val starId: Long,
+    @field:JsonProperty("essentialMsgSwitch")
+    val essentialMsgSwitch: Long,
+    @field:JsonProperty("todoSeq")
+    val todoSeq: Long,
+    @field:JsonProperty("blacklistExpireTime")
+    val blacklistExpireTime: Long,
+    @field:JsonProperty("isLimitGroupRtc")
+    val isLimitGroupRtc: Long,
+    @field:JsonProperty("companyId")
+    val companyId: Long,
+    @field:JsonProperty("hasGroupCustomPortrait")
+    val hasGroupCustomPortrait: Long,
+    @field:JsonProperty("bindGuildId")
+    val bindGuildId: String,
+    @field:JsonProperty("groupOwnerId")
+    val groupOwnerId: GetGroupInfoExDataExtInfoGroupOwnerId,
+    @field:JsonProperty("essentialMsgPrivilege")
+    val essentialMsgPrivilege: Long,
+    @field:JsonProperty("msgEventSeq")
+    val msgEventSeq: String,
+    @field:JsonProperty("inviteRobotSwitch")
+    val inviteRobotSwitch: Long,
+    @field:JsonProperty("gangUpId")
+    val gangUpId: String,
+    @field:JsonProperty("qqMusicMedalSwitch")
+    val qqMusicMedalSwitch: Long,
+    @field:JsonProperty("showPlayTogetherSwitch")
+    val showPlayTogetherSwitch: Long,
+    @field:JsonProperty("groupFlagPro1")
+    val groupFlagPro1: String,
+    @field:JsonProperty("groupBindGuildIds")
+    val groupBindGuildIds: GetGroupInfoExDataExtInfoGroupBindGuildIds,
+    @field:JsonProperty("viewedMsgDisappearTime")
+    val viewedMsgDisappearTime: String,
+    @field:JsonProperty("groupExtFlameData")
+    val groupExtFlameData: GetGroupInfoExDataExtInfoGroupExtFlameData,
+    @field:JsonProperty("groupBindGuildSwitch")
+    val groupBindGuildSwitch: Long,
+    @field:JsonProperty("groupAioBindGuildId")
+    val groupAioBindGuildId: String,
+    @field:JsonProperty("groupExcludeGuildIds")
+    val groupExcludeGuildIds: GetGroupInfoExDataExtInfoGroupExcludeGuildIds,
+    @field:JsonProperty("fullGroupExpansionSwitch")
+    val fullGroupExpansionSwitch: Long,
+    @field:JsonProperty("fullGroupExpansionSeq")
+    val fullGroupExpansionSeq: String,
+    @field:JsonProperty("inviteRobotMemberSwitch")
+    val inviteRobotMemberSwitch: Long,
+    @field:JsonProperty("inviteRobotMemberExamine")
+    val inviteRobotMemberExamine: Long,
+    @field:JsonProperty("groupSquareSwitch")
+    val groupSquareSwitch: Long
+)
+
+/**
+ * GetGroupInfoExData
+ */
+data class GetGroupInfoExData(
+    @field:JsonProperty("groupCode")
+    val groupCode: String,
+    @field:JsonProperty("resultCode")
+    val resultCode: Long,
+    @field:JsonProperty("extInfo")
+    val extInfo: GetGroupInfoExDataExtInfo
+)
+
+/**
+ * NapCatGroupExtraExpand
+ */
+class NapCatGroupExtraExpand
+
+/**
+ * 删除群相册媒体
+ */
+suspend fun NapCatBotApi.delGroupAlbumMedia(groupId: String, albumId: String, lloc: String) {
+    apiRequestUnit("del_group_album_media", mapOf("group_id" to groupId, "album_id" to albumId, "lloc" to lloc))
+}
+
+/**
+ * 发表群相册评论
+ */
+suspend fun NapCatBotApi.doGroupAlbumComment(groupId: String, albumId: String, lloc: String, content: String) {
+    apiRequestUnit("do_group_album_comment", mapOf("group_id" to groupId, "album_id" to albumId, "lloc" to lloc, "content" to content))
+}
+
+/**
+ * 获取群相册媒体列表
+ */
+suspend fun NapCatBotApi.getGroupAlbumMediaList(groupId: String, albumId: String, attachInfo: String): String {
+    return apiRequest("get_group_album_media_list", mapOf("group_id" to groupId, "album_id" to albumId, "attach_info" to attachInfo))
+}
+
+/**
+ * 获取群信息ex
+ */
+suspend fun NapCatBotApi.getGroupInfoEx(groupId: Long): GetGroupInfoExData {
+    return apiRequest("get_group_info_ex", mapOf("group_id" to groupId))
+}
+
+/**
+ * 获取群相册列表
+ */
+suspend fun NapCatBotApi.getQunAlbumList(groupId: String): List<String> {
+    return apiRequest("get_qun_album_list", mapOf("group_id" to groupId))
+}
+
+/**
+ * 群打卡
+ */
+suspend fun NapCatBotApi.sendGroupSign(groupId: String) {
+    apiRequestUnit("send_group_sign", mapOf("group_id" to groupId))
+}
+
+/**
+ * 设置群添加选项
+ */
+suspend fun NapCatBotApi.setGroupAddOption(groupId: Long, addType: String, groupQuestion: String? = null, groupAnswer: String? = null) {
+    apiRequestUnit("set_group_add_option", mapOf("group_id" to groupId, "add_type" to addType, "group_question" to groupQuestion, "group_answer" to groupAnswer))
+}
+
+/**
+ * 点赞群相册媒体
+ */
+suspend fun NapCatBotApi.setGroupAlbumMediaLike(groupId: String, albumId: String, lloc: String, id: String, set: Boolean) {
+    apiRequestUnit("set_group_album_media_like", mapOf("group_id" to groupId, "album_id" to albumId, "lloc" to lloc, "id" to id, "set" to set))
+}
+
+/**
+ * 设置群备注
+ */
+suspend fun NapCatBotApi.setGroupRemark(groupId: String, remark: String) {
+    apiRequestUnit("set_group_remark", mapOf("group_id" to groupId, "remark" to remark))
+}
+
+/**
+ * 设置群机器人添加选项
+ */
+suspend fun NapCatBotApi.setGroupRobotAddOption(groupId: Long, robotMemberSwitch: Long? = null, robotMemberExamine: Long? = null) {
+    apiRequestUnit("set_group_robot_add_option", mapOf("group_id" to groupId, "robot_member_switch" to robotMemberSwitch, "robot_member_examine" to robotMemberExamine))
+}
+
+/**
+ * 设置群搜索
+ */
+suspend fun NapCatBotApi.setGroupSearch(groupId: Long, noCodeFingerOpen: Long? = null, noFingerOpen: Long? = null) {
+    apiRequestUnit("set_group_search", mapOf("group_id" to groupId, "no_code_finger_open" to noCodeFingerOpen, "no_finger_open" to noFingerOpen))
+}
+
+/**
+ * 群打卡
+ */
+suspend fun NapCatBotApi.setGroupSign(groupId: String) {
+    apiRequestUnit("set_group_sign", mapOf("group_id" to groupId))
+}
+
+/**
+ * 上传图片到群相册
+ */
+suspend fun NapCatBotApi.uploadImageToQunAlbum(groupId: String, albumId: String, albumName: String, file: String) {
+    apiRequestUnit("upload_image_to_qun_album", mapOf("group_id" to groupId, "album_id" to albumId, "album_name" to albumName, "file" to file))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatGuildApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatGuildApiExpand.kt
@@ -1,0 +1,24 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+
+/**
+ * NapCatGuildApiExpand
+ */
+class NapCatGuildApiExpand
+
+/**
+ * get_guild_list
+ */
+suspend fun NapCatBotApi.getGuildList(): NapCatRawData {
+    return apiRequest("get_guild_list")
+}
+
+/**
+ * get_guild_service_profile
+ */
+suspend fun NapCatBotApi.getGuildServiceProfile(): NapCatRawData {
+    return apiRequest("get_guild_service_profile")
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatMessageApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatMessageApiExpand.kt
@@ -1,0 +1,96 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+
+/**
+ * NapCatMessageApiExpand
+ */
+class NapCatMessageApiExpand
+
+/**
+ * _设置所有消息已读
+ */
+suspend fun NapCatBotApi.markAllAsRead() {
+    apiRequestUnit("_mark_all_as_read")
+}
+
+/**
+ * 撤回消息
+ */
+suspend fun NapCatBotApi.deleteMsg(messageId: Long) {
+    apiRequestUnit("delete_msg", mapOf("message_id" to messageId))
+}
+
+/**
+ * 消息转发到私聊
+ */
+suspend fun NapCatBotApi.forwardFriendSingleMsg(userId: Long, messageId: Long) {
+    apiRequestUnit("forward_friend_single_msg", mapOf("user_id" to userId, "message_id" to messageId))
+}
+
+/**
+ * 消息转发到群
+ */
+suspend fun NapCatBotApi.forwardGroupSingleMsg(groupId: Long, messageId: Long) {
+    apiRequestUnit("forward_group_single_msg", mapOf("group_id" to groupId, "message_id" to messageId))
+}
+
+/**
+ * 获取消息详情
+ */
+suspend fun NapCatBotApi.getMsg(messageId: Long): NapCatRawData {
+    return apiRequest("get_msg", mapOf("message_id" to messageId))
+}
+
+/**
+ * 设置群聊已读
+ */
+suspend fun NapCatBotApi.markGroupMsgAsRead(groupId: Long) {
+    apiRequestUnit("mark_group_msg_as_read", mapOf("group_id" to groupId))
+}
+
+/**
+ * 设置消息已读
+ */
+suspend fun NapCatBotApi.markMsgAsRead(groupId: Long? = null, userId: Long? = null) {
+    apiRequestUnit("mark_msg_as_read", mapOf("group_id" to groupId, "user_id" to userId))
+}
+
+/**
+ * 设置私聊已读
+ */
+suspend fun NapCatBotApi.markPrivateMsgAsRead(userId: Long) {
+    apiRequestUnit("mark_private_msg_as_read", mapOf("user_id" to userId))
+}
+
+/**
+ * send_msg
+ */
+suspend fun NapCatBotApi.sendMsg(messageType: String, groupId: Long, userId: Long, message: List<Any>) {
+    apiRequestUnit("send_msg", mapOf("message_type" to messageType, "group_id" to groupId, "user_id" to userId, "message" to message))
+}
+
+/**
+ * 设置输入状态
+ *
+ * ## 状态列表
+
+### 对方正在说话...
+
+ */
+suspend fun NapCatBotApi.setInputStatus() {
+    apiRequestUnit("set_input_status")
+}
+
+/**
+ * 设置在线状态
+ *
+ * ## 状态列表
+
+### 在线
+ */
+suspend fun NapCatBotApi.setOnlineStatus() {
+    apiRequestUnit("set_online_status")
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatMessageExtraExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatMessageExtraExpand.kt
@@ -1,0 +1,131 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * ArkSharePeerData
+ */
+data class ArkSharePeerData(
+    @field:JsonProperty("errCode")
+    val errCode: Long,
+    @field:JsonProperty("errMsg")
+    val errMsg: String,
+    @field:JsonProperty("arkJson")
+    val arkJson: String
+)
+
+/**
+ * FetchEmojiLikeDataEmojiLikesListItem
+ */
+data class FetchEmojiLikeDataEmojiLikesListItem(
+    @field:JsonProperty("tinyId")
+    val tinyId: String,
+    @field:JsonProperty("nickName")
+    val nickName: String,
+    @field:JsonProperty("headUrl")
+    val headUrl: String
+)
+
+/**
+ * FetchEmojiLikeData
+ */
+data class FetchEmojiLikeData(
+    @field:JsonProperty("result")
+    val result: Long,
+    @field:JsonProperty("errMsg")
+    val errMsg: String,
+    @field:JsonProperty("emojiLikesList")
+    val emojiLikesList: List<FetchEmojiLikeDataEmojiLikesListItem>,
+    @field:JsonProperty("cookie")
+    val cookie: String,
+    @field:JsonProperty("isLastPage")
+    val isLastPage: Boolean,
+    @field:JsonProperty("isFirstPage")
+    val isFirstPage: Boolean
+)
+
+/**
+ * GetEmojiLikesDataEmojiLikeListItem
+ */
+data class GetEmojiLikesDataEmojiLikeListItem(
+    @field:JsonProperty("user_id")
+    val userId: String,
+    @field:JsonProperty("nick_name")
+    val nickName: String
+)
+
+/**
+ * GetEmojiLikesData
+ */
+data class GetEmojiLikesData(
+    @field:JsonProperty("emoji_like_list")
+    val emojiLikeList: List<GetEmojiLikesDataEmojiLikeListItem>
+)
+
+/**
+ * NapCatMessageExtraExpand
+ */
+class NapCatMessageExtraExpand
+
+/**
+ * 获取推荐群聊卡片
+ */
+suspend fun NapCatBotApi.ArkShareGroup(groupId: String): String {
+    return apiRequest("ArkShareGroup", mapOf("group_id" to groupId))
+}
+
+/**
+ * 获取推荐好友/群聊卡片
+ */
+suspend fun NapCatBotApi.ArkSharePeer(groupId: Long? = null, userId: Long? = null, phoneNumber: String? = null): ArkSharePeerData {
+    return apiRequest("ArkSharePeer", mapOf("group_id" to groupId, "user_id" to userId, "phoneNumber" to phoneNumber))
+}
+
+/**
+ * 点击按钮
+ */
+suspend fun NapCatBotApi.clickInlineKeyboardButton(groupId: Long, botAppid: String, buttonId: String, callbackData: String, msgSeq: String) {
+    apiRequestUnit("click_inline_keyboard_button", mapOf("group_id" to groupId, "bot_appid" to botAppid, "button_id" to buttonId, "callback_data" to callbackData, "msg_seq" to msgSeq))
+}
+
+/**
+ * 获取贴表情详情
+ */
+suspend fun NapCatBotApi.fetchEmojiLike(messageId: Long, emojiId: String, emojiType: String, count: Long? = null): FetchEmojiLikeData {
+    return apiRequest("fetch_emoji_like", mapOf("message_id" to messageId, "emojiId" to emojiId, "emojiType" to emojiType, "count" to count))
+}
+
+/**
+ * 获取消息表情点赞列表
+ */
+suspend fun NapCatBotApi.getEmojiLikes(groupId: String? = null, messageId: String, emojiId: String, emojiType: String? = null, count: Long): GetEmojiLikesData {
+    return apiRequest("get_emoji_likes", mapOf("group_id" to groupId, "message_id" to messageId, "emoji_id" to emojiId, "emoji_type" to emojiType, "count" to count))
+}
+
+/**
+ * 分享用户 (Ark)
+ *
+ * 获取用户推荐的 Ark 内容
+ */
+suspend fun NapCatBotApi.sendArkShare(userId: String? = null, groupId: String? = null, phoneNumber: String) {
+    apiRequestUnit("send_ark_share", mapOf("user_id" to userId, "group_id" to groupId, "phone_number" to phoneNumber))
+}
+
+/**
+ * 分享群 (Ark)
+ *
+ * 获取群分享的 Ark 内容
+ */
+suspend fun NapCatBotApi.sendGroupArkShare(groupId: String) {
+    apiRequestUnit("send_group_ark_share", mapOf("group_id" to groupId))
+}
+
+/**
+ * 贴表情
+ */
+suspend fun NapCatBotApi.setMsgEmojiLike(messageId: Long, emojiId: Long, set: Boolean) {
+    apiRequestUnit("set_msg_emoji_like", mapOf("message_id" to messageId, "emoji_id" to emojiId, "set" to set))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatMessageGroupSendExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatMessageGroupSendExpand.kt
@@ -1,0 +1,19 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+
+/**
+ * NapCatMessageGroupSendExpand
+ */
+class NapCatMessageGroupSendExpand
+
+/**
+ * 发送群艾特
+ *
+ * 发送群消息
+ */
+suspend fun NapCatBotApi.sendGroupMsg(groupId: Long, message: List<MessageItem>) {
+    apiRequestUnit("send_group_msg", mapOf("group_id" to groupId, "message" to message))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatMessagePrivateSendExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatMessagePrivateSendExpand.kt
@@ -1,0 +1,19 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+
+/**
+ * NapCatMessagePrivateSendExpand
+ */
+class NapCatMessagePrivateSendExpand
+
+/**
+ * 发送私聊图片
+ *
+ * 发送群消息
+ */
+suspend fun NapCatBotApi.sendPrivateMsg(userId: Long, message: List<Any>) {
+    apiRequestUnit("send_private_msg", mapOf("user_id" to userId, "message" to message))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatNapCatOtherApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatNapCatOtherApiExpand.kt
@@ -1,0 +1,17 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+
+/**
+ * NapCatNapCatOtherApiExpand
+ */
+class NapCatNapCatOtherApiExpand
+
+/**
+ * unknown
+ */
+suspend fun NapCatBotApi.unknown() {
+    apiRequestUnit("unknown")
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatStreamApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatStreamApiExpand.kt
@@ -1,0 +1,28 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+
+/**
+ * NapCatStreamApiExpand
+ */
+class NapCatStreamApiExpand
+
+/**
+ * 下载文件流
+ *
+ * 以流式方式从网络或本地下载文件
+ */
+suspend fun NapCatBotApi.downloadFileStream(file: String? = null, fileId: String? = null, chunkSize: Long? = null): String {
+    return apiRequest("download_file_stream", mapOf("file" to file, "file_id" to fileId, "chunk_size" to chunkSize))
+}
+
+/**
+ * 上传文件流
+ *
+ * 以流式方式上传文件数据到机器人
+ */
+suspend fun NapCatBotApi.uploadFileStream(streamId: String, chunkData: String? = null, chunkIndex: Long? = null, totalChunks: Long? = null, fileSize: Long? = null, expectedSha256: String? = null, isComplete: Boolean? = null, filename: String? = null, reset: Boolean? = null, verifyOnly: Boolean? = null, fileRetention: Long) {
+    apiRequestUnit("upload_file_stream", mapOf("stream_id" to streamId, "chunk_data" to chunkData, "chunk_index" to chunkIndex, "total_chunks" to totalChunks, "file_size" to fileSize, "expected_sha256" to expectedSha256, "is_complete" to isComplete, "filename" to filename, "reset" to reset, "verify_only" to verifyOnly, "file_retention" to fileRetention))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatStreamTransferExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatStreamTransferExpand.kt
@@ -1,0 +1,38 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+
+/**
+ * NapCatStreamTransferExpand
+ */
+class NapCatStreamTransferExpand
+
+/**
+ * 清理流式传输临时文件
+ */
+suspend fun NapCatBotApi.cleanStreamTempFile() {
+    apiRequestUnit("clean_stream_temp_file")
+}
+
+/**
+ * 下载图片文件流
+ */
+suspend fun NapCatBotApi.downloadFileImageStream(file: String? = null, fileId: String? = null, chunkSize: Long? = null): String {
+    return apiRequest("download_file_image_stream", mapOf("file" to file, "file_id" to fileId, "chunk_size" to chunkSize))
+}
+
+/**
+ * 下载语音文件流
+ */
+suspend fun NapCatBotApi.downloadFileRecordStream(file: String? = null, fileId: String? = null, chunkSize: Long? = null, outFormat: String? = null): String {
+    return apiRequest("download_file_record_stream", mapOf("file" to file, "file_id" to fileId, "chunk_size" to chunkSize, "out_format" to outFormat))
+}
+
+/**
+ * 测试下载流
+ */
+suspend fun NapCatBotApi.testDownloadStream(error: Boolean? = null): String {
+    return apiRequest("test_download_stream", mapOf("error" to error))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatSystemApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatSystemApiExpand.kt
@@ -1,0 +1,212 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * CanSendImageData
+ */
+data class CanSendImageData(
+    @field:JsonProperty("yes")
+    val yes: Boolean
+)
+
+/**
+ * CanSendRecordData
+ */
+data class CanSendRecordData(
+    @field:JsonProperty("yes")
+    val yes: Boolean
+)
+
+/**
+ * GetCredentialsData
+ */
+data class GetCredentialsData(
+    @field:JsonProperty("cookies")
+    val cookies: String,
+    @field:JsonProperty("token")
+    val token: Long
+)
+
+/**
+ * GetCsrfTokenData
+ */
+data class GetCsrfTokenData(
+    @field:JsonProperty("token")
+    val token: Long
+)
+
+/**
+ * GetDoubtFriendsAddRequestDataItem
+ */
+data class GetDoubtFriendsAddRequestDataItem(
+    @field:JsonProperty("flag")
+    val flag: String,
+    @field:JsonProperty("uin")
+    val uin: String,
+    @field:JsonProperty("nick")
+    val nick: String,
+    @field:JsonProperty("source")
+    val source: String,
+    @field:JsonProperty("reason")
+    val reason: String,
+    @field:JsonProperty("msg")
+    val msg: String,
+    @field:JsonProperty("group_code")
+    val groupCode: String,
+    @field:JsonProperty("time")
+    val time: String,
+    @field:JsonProperty("type")
+    val type: String
+)
+
+/**
+ * GetGroupSystemMsgData
+ */
+data class GetGroupSystemMsgData(
+    @field:JsonProperty("InvitedRequest")
+    val InvitedRequest: List<Any>,
+    @field:JsonProperty("join_requests")
+    val joinRequests: List<Any>
+)
+
+/**
+ * GetLoginInfoData
+ */
+data class GetLoginInfoData(
+    @field:JsonProperty("user_id")
+    val userId: Long,
+    @field:JsonProperty("nickname")
+    val nickname: String
+)
+
+/**
+ * GetStatusData
+ */
+data class GetStatusData(
+    @field:JsonProperty("online")
+    val online: Boolean,
+    @field:JsonProperty("good")
+    val good: Boolean,
+    @field:JsonProperty("stat")
+    val stat: NapCatRawData
+)
+
+/**
+ * GetVersionInfoData
+ */
+data class GetVersionInfoData(
+    @field:JsonProperty("app_name")
+    val appName: String,
+    @field:JsonProperty("protocol_version")
+    val protocolVersion: String,
+    @field:JsonProperty("app_version")
+    val appVersion: String
+)
+
+/**
+ * NapCatSystemApiExpand
+ */
+class NapCatSystemApiExpand
+
+/**
+ * 检查是否可以发送图片
+ */
+suspend fun NapCatBotApi.canSendImage(): CanSendImageData {
+    return apiRequest("can_send_image")
+}
+
+/**
+ * 检查是否可以发送语音
+ */
+suspend fun NapCatBotApi.canSendRecord(): CanSendRecordData {
+    return apiRequest("can_send_record")
+}
+
+/**
+ * 清空缓存
+ */
+suspend fun NapCatBotApi.cleanCache() {
+    apiRequestUnit("clean_cache")
+}
+
+/**
+ * 获取 QQ 相关接口凭证
+ */
+suspend fun NapCatBotApi.getCredentials(domain: String): GetCredentialsData {
+    return apiRequest("get_credentials", mapOf("domain" to domain))
+}
+
+/**
+ * 获取 CSRF Token
+ */
+suspend fun NapCatBotApi.getCsrfToken(): GetCsrfTokenData {
+    return apiRequest("get_csrf_token")
+}
+
+/**
+ * 获取被过滤好友请求
+ */
+suspend fun NapCatBotApi.getDoubtFriendsAddRequest(count: Long): List<GetDoubtFriendsAddRequestDataItem> {
+    return apiRequest("get_doubt_friends_add_request", mapOf("count" to count))
+}
+
+/**
+ * 获取群系统消息
+ */
+suspend fun NapCatBotApi.getGroupSystemMsg(count: Long): GetGroupSystemMsgData {
+    return apiRequest("get_group_system_msg", mapOf("count" to count))
+}
+
+/**
+ * 获取登录号信息
+ */
+suspend fun NapCatBotApi.getLoginInfo(): GetLoginInfoData {
+    return apiRequest("get_login_info")
+}
+
+/**
+ * 获取状态
+ */
+suspend fun NapCatBotApi.getStatus(): GetStatusData {
+    return apiRequest("get_status")
+}
+
+/**
+ * 获取版本信息
+ */
+suspend fun NapCatBotApi.getVersionInfo(): GetVersionInfoData {
+    return apiRequest("get_version_info")
+}
+
+/**
+ * 获取packet状态
+ */
+suspend fun NapCatBotApi.ncGetPacketStatus(): Any {
+    return apiRequest("nc_get_packet_status")
+}
+
+/**
+ * 处理被过滤好友请求
+ *
+ *  在 4.7.43 版本中 
+approve 的值无效
+调用该接口既是同意好友请求！！！
+调用该接口既是同意好友请求！！！
+调用该接口既是同意好友请求！！！
+ */
+suspend fun NapCatBotApi.setDoubtFriendsAddRequest(flag: String, approve: Boolean) {
+    apiRequestUnit("set_doubt_friends_add_request", mapOf("flag" to flag, "approve" to approve))
+}
+
+/**
+ * 重启服务
+ *
+ * 重启服务
+ */
+suspend fun NapCatBotApi.setRestart() {
+    apiRequestUnit("set_restart")
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatSystemExtraExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatSystemExtraExpand.kt
@@ -1,0 +1,335 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * GetCollectionListDataCollectionSearchListCollectionItemListItemAuthor
+ */
+data class GetCollectionListDataCollectionSearchListCollectionItemListItemAuthor(
+    @field:JsonProperty("type")
+    val type: Long,
+    @field:JsonProperty("numId")
+    val numId: String,
+    @field:JsonProperty("strId")
+    val strId: String,
+    @field:JsonProperty("groupId")
+    val groupId: String,
+    @field:JsonProperty("groupName")
+    val groupName: String,
+    @field:JsonProperty("uid")
+    val uid: String
+)
+
+/**
+ * GetCollectionListDataCollectionSearchListCollectionItemListItemSummary
+ */
+data class GetCollectionListDataCollectionSearchListCollectionItemListItemSummary(
+    @field:JsonProperty("textSummary")
+    val textSummary: String,
+    @field:JsonProperty("linkSummary")
+    val linkSummary: String,
+    @field:JsonProperty("gallerySummary")
+    val gallerySummary: String,
+    @field:JsonProperty("audioSummary")
+    val audioSummary: String,
+    @field:JsonProperty("videoSummary")
+    val videoSummary: String,
+    @field:JsonProperty("fileSummary")
+    val fileSummary: String,
+    @field:JsonProperty("locationSummary")
+    val locationSummary: String,
+    @field:JsonProperty("richMediaSummary")
+    val richMediaSummary: String
+)
+
+/**
+ * GetCollectionListDataCollectionSearchListCollectionItemListItem
+ */
+data class GetCollectionListDataCollectionSearchListCollectionItemListItem(
+    @field:JsonProperty("cid")
+    val cid: String,
+    @field:JsonProperty("type")
+    val type: Long,
+    @field:JsonProperty("status")
+    val status: Long,
+    @field:JsonProperty("author")
+    val author: GetCollectionListDataCollectionSearchListCollectionItemListItemAuthor,
+    @field:JsonProperty("bid")
+    val bid: Long,
+    @field:JsonProperty("category")
+    val category: Long,
+    @field:JsonProperty("createTime")
+    val createTime: String,
+    @field:JsonProperty("collectTime")
+    val collectTime: String,
+    @field:JsonProperty("modifyTime")
+    val modifyTime: String,
+    @field:JsonProperty("sequence")
+    val sequence: String,
+    @field:JsonProperty("shareUrl")
+    val shareUrl: String,
+    @field:JsonProperty("customGroupId")
+    val customGroupId: Long,
+    @field:JsonProperty("securityBeat")
+    val securityBeat: Boolean,
+    @field:JsonProperty("summary")
+    val summary: GetCollectionListDataCollectionSearchListCollectionItemListItemSummary
+)
+
+/**
+ * GetCollectionListDataCollectionSearchList
+ */
+data class GetCollectionListDataCollectionSearchList(
+    @field:JsonProperty("collectionItemList")
+    val collectionItemList: List<GetCollectionListDataCollectionSearchListCollectionItemListItem>,
+    @field:JsonProperty("hasMore")
+    val hasMore: Boolean,
+    @field:JsonProperty("bottomTimeStamp")
+    val bottomTimeStamp: String
+)
+
+/**
+ * GetCollectionListData
+ */
+data class GetCollectionListData(
+    @field:JsonProperty("result")
+    val result: Long,
+    @field:JsonProperty("errMsg")
+    val errMsg: String,
+    @field:JsonProperty("collectionSearchList")
+    val collectionSearchList: GetCollectionListDataCollectionSearchList
+)
+
+/**
+ * GetMiniAppArkDataMetaDataDetail1Host
+ */
+data class GetMiniAppArkDataMetaDataDetail1Host(
+    @field:JsonProperty("uin")
+    val uin: Long,
+    @field:JsonProperty("nick")
+    val nick: String
+)
+
+/**
+ * GetMiniAppArkDataMetaDataDetail1
+ */
+data class GetMiniAppArkDataMetaDataDetail1(
+    @field:JsonProperty("appid")
+    val appid: String,
+    @field:JsonProperty("appType")
+    val appType: Long,
+    @field:JsonProperty("title")
+    val title: String,
+    @field:JsonProperty("desc")
+    val desc: String,
+    @field:JsonProperty("icon")
+    val icon: String,
+    @field:JsonProperty("preview")
+    val preview: String,
+    @field:JsonProperty("url")
+    val url: String,
+    @field:JsonProperty("scene")
+    val scene: Long,
+    @field:JsonProperty("host")
+    val host: GetMiniAppArkDataMetaDataDetail1Host,
+    @field:JsonProperty("shareTemplateId")
+    val shareTemplateId: String,
+    @field:JsonProperty("shareTemplateData")
+    val shareTemplateData: NapCatRawData,
+    @field:JsonProperty("showLittleTail")
+    val showLittleTail: String,
+    @field:JsonProperty("gamePoints")
+    val gamePoints: String,
+    @field:JsonProperty("gamePointsUrl")
+    val gamePointsUrl: String,
+    @field:JsonProperty("shareOrigin")
+    val shareOrigin: Long
+)
+
+/**
+ * GetMiniAppArkDataMetaData
+ */
+data class GetMiniAppArkDataMetaData(
+    @field:JsonProperty("detail_1")
+    val detail1: GetMiniAppArkDataMetaDataDetail1
+)
+
+/**
+ * GetMiniAppArkDataConfig
+ */
+data class GetMiniAppArkDataConfig(
+    @field:JsonProperty("type")
+    val type: String,
+    @field:JsonProperty("width")
+    val width: Long,
+    @field:JsonProperty("height")
+    val height: Long,
+    @field:JsonProperty("forward")
+    val forward: Long,
+    @field:JsonProperty("autoSize")
+    val autoSize: Long,
+    @field:JsonProperty("ctime")
+    val ctime: Long,
+    @field:JsonProperty("token")
+    val token: String
+)
+
+/**
+ * GetMiniAppArkData
+ */
+data class GetMiniAppArkData(
+    @field:JsonProperty("appName")
+    val appName: String,
+    @field:JsonProperty("appView")
+    val appView: String,
+    @field:JsonProperty("ver")
+    val ver: String,
+    @field:JsonProperty("desc")
+    val desc: String,
+    @field:JsonProperty("prompt")
+    val prompt: String,
+    @field:JsonProperty("metaData")
+    val metaData: GetMiniAppArkDataMetaData,
+    @field:JsonProperty("config")
+    val config: GetMiniAppArkDataConfig
+)
+
+/**
+ * GetRkeyDataItem
+ */
+data class GetRkeyDataItem(
+    @field:JsonProperty("type")
+    val type: String,
+    @field:JsonProperty("rkey")
+    val rkey: String,
+    @field:JsonProperty("created_at")
+    val createdAt: Long,
+    @field:JsonProperty("ttl")
+    val ttl: String
+)
+
+/**
+ * GetRkeyServerData
+ */
+data class GetRkeyServerData(
+    @field:JsonProperty("private_rkey")
+    val privateRkey: String,
+    @field:JsonProperty("group_rkey")
+    val groupRkey: String,
+    @field:JsonProperty("expired_time")
+    val expiredTime: Long,
+    @field:JsonProperty("name")
+    val name: String
+)
+
+/**
+ * GetRobotUinRangeDataItem
+ */
+data class GetRobotUinRangeDataItem(
+    @field:JsonProperty("minUin")
+    val minUin: String,
+    @field:JsonProperty("maxUin")
+    val maxUin: String
+)
+
+/**
+ * NcGetRkeyDataItem
+ */
+data class NcGetRkeyDataItem(
+    @field:JsonProperty("rkey")
+    val rkey: String,
+    @field:JsonProperty("ttl")
+    val ttl: String,
+    @field:JsonProperty("time")
+    val time: Long,
+    @field:JsonProperty("type")
+    val type: Long
+)
+
+/**
+ * NcGetUserStatusData
+ */
+data class NcGetUserStatusData(
+    @field:JsonProperty("status")
+    val status: Long,
+    @field:JsonProperty("ext_status")
+    val extStatus: Long
+)
+
+/**
+ * NapCatSystemExtraExpand
+ */
+class NapCatSystemExtraExpand
+
+/**
+ * 账号退出
+ */
+suspend fun NapCatBotApi.botExit() {
+    apiRequestUnit("bot_exit")
+}
+
+/**
+ * 获取收藏表情
+ */
+suspend fun NapCatBotApi.fetchCustomFace(count: Long? = null): List<String> {
+    return apiRequest("fetch_custom_face", mapOf("count" to count))
+}
+
+/**
+ * 获取收藏列表
+ */
+suspend fun NapCatBotApi.getCollectionList(category: Long, count: Long): GetCollectionListData {
+    return apiRequest("get_collection_list", mapOf("category" to category, "count" to count))
+}
+
+/**
+ * 获取小程序卡片
+ */
+suspend fun NapCatBotApi.getMiniAppArk(): GetMiniAppArkData {
+    return apiRequest("get_mini_app_ark")
+}
+
+/**
+ * 获取rkey
+ */
+suspend fun NapCatBotApi.getRkey(): List<GetRkeyDataItem> {
+    return apiRequest("get_rkey")
+}
+
+/**
+ * 获取rkey服务
+ */
+suspend fun NapCatBotApi.getRkeyServer(): GetRkeyServerData {
+    return apiRequest("get_rkey_server")
+}
+
+/**
+ * 获取机器人账号范围
+ */
+suspend fun NapCatBotApi.getRobotUinRange(): List<GetRobotUinRangeDataItem> {
+    return apiRequest("get_robot_uin_range")
+}
+
+/**
+ * nc获取rkey
+ */
+suspend fun NapCatBotApi.ncGetRkey(): List<NcGetRkeyDataItem> {
+    return apiRequest("nc_get_rkey")
+}
+
+/**
+ * 获取用户状态
+ */
+suspend fun NapCatBotApi.ncGetUserStatus(userId: Long): NcGetUserStatusData {
+    return apiRequest("nc_get_user_status", mapOf("user_id" to userId))
+}
+
+/**
+ * 发送自定义组包
+ */
+suspend fun NapCatBotApi.sendPacket() {
+    apiRequestUnit("send_packet")
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatUserApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatUserApiExpand.kt
@@ -1,0 +1,139 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * GetCookiesData
+ */
+data class GetCookiesData(
+    @field:JsonProperty("cookies")
+    val cookies: String,
+    @field:JsonProperty("bkn")
+    val bkn: String
+)
+
+/**
+ * GetRecentContactDataItemLastestMsgSender
+ */
+data class GetRecentContactDataItemLastestMsgSender(
+    @field:JsonProperty("user_id")
+    val userId: Long,
+    @field:JsonProperty("nickname")
+    val nickname: String,
+    @field:JsonProperty("sex")
+    val sex: String?,
+    @field:JsonProperty("age")
+    val age: Long?,
+    @field:JsonProperty("card")
+    val card: String,
+    @field:JsonProperty("role")
+    val role: String?
+)
+
+/**
+ * GetRecentContactDataItemLastestMsg
+ */
+data class GetRecentContactDataItemLastestMsg(
+    @field:JsonProperty("self_id")
+    val selfId: Long,
+    @field:JsonProperty("user_id")
+    val userId: Long,
+    @field:JsonProperty("time")
+    val time: Long,
+    @field:JsonProperty("real_seq")
+    val realSeq: String,
+    @field:JsonProperty("message_type")
+    val messageType: String,
+    @field:JsonProperty("sender")
+    val sender: GetRecentContactDataItemLastestMsgSender,
+    @field:JsonProperty("raw_message")
+    val rawMessage: String,
+    @field:JsonProperty("font")
+    val font: Long,
+    @field:JsonProperty("sub_type")
+    val subType: String,
+    @field:JsonProperty("message")
+    val message: List<Any>,
+    @field:JsonProperty("message_format")
+    val messageFormat: String,
+    @field:JsonProperty("post_type")
+    val postType: String,
+    @field:JsonProperty("group_id")
+    val groupId: Long?
+)
+
+/**
+ * GetRecentContactDataItem
+ */
+data class GetRecentContactDataItem(
+    @field:JsonProperty("lastestMsg")
+    val lastestMsg: GetRecentContactDataItemLastestMsg?,
+    @field:JsonProperty("peerUin")
+    val peerUin: String,
+    @field:JsonProperty("remark")
+    val remark: String,
+    @field:JsonProperty("msgTime")
+    val msgTime: String,
+    @field:JsonProperty("chatType")
+    val chatType: Long,
+    @field:JsonProperty("msgId")
+    val msgId: String,
+    @field:JsonProperty("sendNickName")
+    val sendNickName: String,
+    @field:JsonProperty("sendMemberName")
+    val sendMemberName: String,
+    @field:JsonProperty("peerName")
+    val peerName: String
+)
+
+/**
+ * NapCatUserApiExpand
+ */
+class NapCatUserApiExpand
+
+/**
+ * 获取cookies
+ */
+suspend fun NapCatBotApi.getCookies(domain: String): GetCookiesData {
+    return apiRequest("get_cookies", mapOf("domain" to domain))
+}
+
+/**
+ * 获取好友列表
+ */
+suspend fun NapCatBotApi.getFriendList(noCache: Boolean): List<NapCatRawData> {
+    return apiRequest("get_friend_list", mapOf("no_cache" to noCache))
+}
+
+/**
+ * 最近消息列表
+ *
+ * 获取的最新消息是每个会话最新的消息
+ */
+suspend fun NapCatBotApi.getRecentContact(count: Long? = null): List<GetRecentContactDataItem> {
+    return apiRequest("get_recent_contact", mapOf("count" to count))
+}
+
+/**
+ * 点赞
+ */
+suspend fun NapCatBotApi.sendLike(userId: Long, times: Long? = null) {
+    apiRequestUnit("send_like", mapOf("user_id" to userId, "times" to times))
+}
+
+/**
+ * 处理好友请求
+ */
+suspend fun NapCatBotApi.setFriendAddRequest(flag: String, approve: Boolean, remark: String) {
+    apiRequestUnit("set_friend_add_request", mapOf("flag" to flag, "approve" to approve, "remark" to remark))
+}
+
+/**
+ * 设置好友备注
+ */
+suspend fun NapCatBotApi.setFriendRemark(userId: Long, remark: String) {
+    apiRequestUnit("set_friend_remark", mapOf("user_id" to userId, "remark" to remark))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatUserExtraExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatUserExtraExpand.kt
@@ -1,0 +1,117 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * GetFriendsWithCategoryDataItem
+ */
+data class GetFriendsWithCategoryDataItem(
+    @field:JsonProperty("categoryId")
+    val categoryId: Long,
+    @field:JsonProperty("categorySortId")
+    val categorySortId: Long,
+    @field:JsonProperty("categoryName")
+    val categoryName: String,
+    @field:JsonProperty("categoryMbCount")
+    val categoryMbCount: Long,
+    @field:JsonProperty("onlineCount")
+    val onlineCount: Long,
+    @field:JsonProperty("buddyList")
+    val buddyList: List<Any>
+)
+
+/**
+ * GetProfileLikeDataFavoriteInfo
+ */
+data class GetProfileLikeDataFavoriteInfo(
+    @field:JsonProperty("total_count")
+    val totalCount: Long,
+    @field:JsonProperty("last_time")
+    val lastTime: Long,
+    @field:JsonProperty("today_count")
+    val todayCount: Long,
+    @field:JsonProperty("userInfos")
+    val userInfos: List<Any>
+)
+
+/**
+ * GetProfileLikeDataVoteInfo
+ */
+data class GetProfileLikeDataVoteInfo(
+    @field:JsonProperty("total_count")
+    val totalCount: Long,
+    @field:JsonProperty("new_count")
+    val newCount: Long,
+    @field:JsonProperty("new_nearby_count")
+    val newNearbyCount: Long,
+    @field:JsonProperty("last_visit_time")
+    val lastVisitTime: Long,
+    @field:JsonProperty("userInfos")
+    val userInfos: List<Any>
+)
+
+/**
+ * GetProfileLikeData
+ */
+data class GetProfileLikeData(
+    @field:JsonProperty("uid")
+    val uid: String,
+    @field:JsonProperty("time")
+    val time: Long,
+    @field:JsonProperty("favoriteInfo")
+    val favoriteInfo: GetProfileLikeDataFavoriteInfo,
+    @field:JsonProperty("voteInfo")
+    val voteInfo: GetProfileLikeDataVoteInfo
+)
+
+/**
+ * GetUnidirectionalFriendListDataItem
+ */
+data class GetUnidirectionalFriendListDataItem(
+    @field:JsonProperty("uin")
+    val uin: Long,
+    @field:JsonProperty("uid")
+    val uid: String,
+    @field:JsonProperty("nick_name")
+    val nickName: String,
+    @field:JsonProperty("age")
+    val age: Long,
+    @field:JsonProperty("source")
+    val source: String
+)
+
+/**
+ * NapCatUserExtraExpand
+ */
+class NapCatUserExtraExpand
+
+/**
+ * 获取好友分组列表
+ */
+suspend fun NapCatBotApi.getFriendsWithCategory(): List<GetFriendsWithCategoryDataItem> {
+    return apiRequest("get_friends_with_category")
+}
+
+/**
+ * 获取点赞列表
+ */
+suspend fun NapCatBotApi.getProfileLike(userId: Long? = null, start: Long? = null, count: Long? = null): GetProfileLikeData {
+    return apiRequest("get_profile_like", mapOf("user_id" to userId, "start" to start, "count" to count))
+}
+
+/**
+ * 获取单向好友列表
+ */
+suspend fun NapCatBotApi.getUnidirectionalFriendList(): List<GetUnidirectionalFriendListDataItem> {
+    return apiRequest("get_unidirectional_friend_list")
+}
+
+/**
+ * 设置自定义在线状态
+ */
+suspend fun NapCatBotApi.setDiyOnlineStatus(faceId: Any, faceType: Any? = null, wording: String? = null) {
+    apiRequestUnit("set_diy_online_status", mapOf("face_id" to faceId, "face_type" to faceType, "wording" to wording))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/bak/NapCatAccountExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/bak/NapCatAccountExpand.kt
@@ -1,4 +1,4 @@
-package com.blr19c.falowp.bot.adapter.nc.expand
+package com.blr19c.falowp.bot.adapter.nc.expand.bak
 
 import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
 import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApiSupport

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/bak/NapCatFileExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/bak/NapCatFileExpand.kt
@@ -1,4 +1,4 @@
-package com.blr19c.falowp.bot.adapter.nc.expand
+package com.blr19c.falowp.bot.adapter.nc.expand.bak
 
 import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
 import com.blr19c.falowp.bot.system.json.Json

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/bak/NapCatGroupExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/bak/NapCatGroupExpand.kt
@@ -1,4 +1,4 @@
-package com.blr19c.falowp.bot.adapter.nc.expand
+package com.blr19c.falowp.bot.adapter.nc.expand.bak
 
 import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
 import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApiSupport

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/bak/NapCatMessageExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/bak/NapCatMessageExpand.kt
@@ -1,4 +1,4 @@
-package com.blr19c.falowp.bot.adapter.nc.expand
+package com.blr19c.falowp.bot.adapter.nc.expand.bak
 
 import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
 import com.blr19c.falowp.bot.adapter.nc.message.NapCatMessage


### PR DESCRIPTION
### Motivation
- Replace the previous manual NapCat expand adapters with generated expansions based on the official API Docs so endpoints stay in sync with documentation. 
- Keep the original implementations available for reference by moving them into an `.bak` package while keeping `NapCatExpandApi.kt` active. 
- Provide typed data-class mappings for query/get-like APIs and a raw fallback for endpoints whose docs lack structured schemas. 
- Maintain the existing coding style and adapter integration patterns (`apiRequest`/`apiRequestUnit`) used by the adapter.

### Description
- Moved original expand files into `com.blr19c.falowp.bot.adapter.nc.expand.bak` (all previous expand files except `NapCatExpandApi.kt` were relocated and package declarations updated). 
- Added `NapCatRawData` to `NapCatExpandApi.kt` and adjusted imports to support raw JsonNode responses for endpoints missing detailed schemas. 
- Implemented a documentation-driven generator and used it to create ~20 new expansion classes under `com.blr19c.falowp.bot.adapter.nc.expand` covering 162 endpoints (examples: `NapCatMessageApiExpand.kt`, `NapCatUserApiExpand.kt`, `NapCatGroupApiExpand.kt`, `NapCatFileApiExpand.kt`, etc.). 
- For each API: request parameters map to function parameters; interaction APIs use `apiRequestUnit(...)`; query/get-like APIs return typed data classes when possible or `NapCatRawData` when schema details are missing.

### Testing
- Ran the doc-parsing/generation script against `https://napcat.apifox.cn/llms.txt`, which fetched API docs and generated expansion sources; generation reported `generated classes 20` and `generated endpoints 162` (success). 
- Installed Python dependencies `requests` and `pyyaml` to enable the generation script; installation completed successfully. 
- Performed repository housekeeping (`git add`, `git commit`) and confirmed changes were committed successfully. 
- No Gradle/compile/unit tests were executed as requested (no build was run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979d75b39b483288f68bc7bc4afe357)