### PR TITLE
Add @param KDoc entries to NapCat API expansion sources

### DIFF
--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatAiExtraExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatAiExtraExpand.kt
@@ -1,0 +1,36 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import tools.jackson.databind.JsonNode
+
+/**
+ * NapCatAiExtraExpand
+ */
+class NapCatAiExtraExpand {
+}
+
+/**
+ * 获取 AI 语音
+ *
+ * 通过 AI 语音引擎获取指定文本的语音 URL
+ * @param character 角色ID
+ * @param groupId 群号
+ * @param text 语音文本内容
+ */
+suspend fun NapCatBotApi.getAiRecord(character: String, groupId: String, text: String): NapCatAiExtraExpand.String {
+    return apiRequest("get_ai_record", mapOf("character" to character, "group_id" to groupId, "text" to text))
+}
+
+/**
+ * 发送群 AI 语音
+ *
+ * 发送 AI 生成的语音到指定群聊
+ * @param character 角色ID
+ * @param groupId 群号
+ * @param text 语音文本内容
+ */
+suspend fun NapCatBotApi.sendGroupAiRecord(character: String, groupId: String, text: String) {
+    apiRequestUnit("send_group_ai_record", mapOf("character" to character, "group_id" to groupId, "text" to text))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatCoreApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatCoreApiExpand.kt
@@ -1,0 +1,60 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import tools.jackson.databind.JsonNode
+
+/**
+ * NapCatCoreApiExpand
+ */
+class NapCatCoreApiExpand {
+}
+
+/**
+ * 发送戳一戳
+ *
+ * 在群聊或私聊中发送戳一戳动作
+ * @param groupId 群号
+ * @param userId 用户QQ
+ * @param targetId 目标QQ
+ */
+suspend fun NapCatBotApi.friendPoke(groupId: String? = null, userId: String, targetId: String? = null) {
+    apiRequestUnit("friend_poke", mapOf("group_id" to groupId, "user_id" to userId, "target_id" to targetId))
+}
+
+/**
+ * 发送戳一戳
+ *
+ * 在群聊或私聊中发送戳一戳动作
+ * @param groupId 群号
+ * @param userId 用户QQ
+ * @param targetId 目标QQ
+ */
+suspend fun NapCatBotApi.groupPoke(groupId: String? = null, userId: String, targetId: String? = null) {
+    apiRequestUnit("group_poke", mapOf("group_id" to groupId, "user_id" to userId, "target_id" to targetId))
+}
+
+/**
+ * 发送戳一戳
+ *
+ * 在群聊或私聊中发送戳一戳动作
+ * @param groupId 群号
+ * @param userId 用户QQ
+ * @param targetId 目标QQ
+ */
+suspend fun NapCatBotApi.sendPoke(groupId: String? = null, userId: String, targetId: String? = null) {
+    apiRequestUnit("send_poke", mapOf("group_id" to groupId, "user_id" to userId, "target_id" to targetId))
+}
+
+/**
+ * 设置群待办
+ *
+ * 将指定消息设置为群待办
+ * @param groupId 群号
+ * @param messageId 消息ID
+ * @param messageSeq 消息Seq (可选)
+ */
+suspend fun NapCatBotApi.setGroupTodo(groupId: String, messageId: String? = null, messageSeq: String? = null) {
+    apiRequestUnit("set_group_todo", mapOf("group_id" to groupId, "message_id" to messageId, "message_seq" to messageSeq))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatExpandApi.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatExpandApi.kt
@@ -104,5 +104,3 @@ internal suspend fun NapCatBotApi.apiRequestUnit(type: String, body: Any? = null
     if (result.success()) return
     throw IllegalStateException("NapCat-API-请求失败:${result.msg ?: ""}${result.wording ?: ""}")
 }
-
-

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatExtraApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatExtraApiExpand.kt
@@ -1,0 +1,164 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import tools.jackson.databind.JsonNode
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * NapCatExtraApiExpand
+ */
+class NapCatExtraApiExpand {
+    /**
+     * AiCharactersItemItemCharactersItem
+     */
+    data class AiCharactersItemItemCharactersItem(
+        /**
+         * 角色ID
+         */
+        @field:JsonProperty("character_id")
+        val characterId: String,
+        /**
+         * 角色名称
+         */
+        @field:JsonProperty("character_name")
+        val characterName: String,
+        /**
+         * 预览URL
+         */
+        @field:JsonProperty("preview_url")
+        val previewUrl: String
+    )
+
+    /**
+     * AiCharactersItemItem
+     */
+    data class AiCharactersItemItem(
+        /**
+         * 角色类型
+         */
+        @field:JsonProperty("type")
+        val type: String,
+        /**
+         * 角色列表
+         */
+        @field:JsonProperty("characters")
+        val characters: List<AiCharactersItemItemCharactersItem>
+    )
+
+    /**
+     * Clientkey
+     */
+    data class Clientkey(
+        /**
+         * 客户端Key
+         */
+        @field:JsonProperty("clientkey")
+        val clientkey: String?
+    )
+
+}
+
+/**
+ * 图片 OCR 识别 (内部)
+ *
+ * 识别图片中的文字内容(仅Windows端支持)
+ * @param image 图片路径、URL或Base64
+ */
+suspend fun NapCatBotApi..ocrImage(image: String) {
+    apiRequestUnit(".ocr_image", mapOf("image" to image))
+}
+
+/**
+ * 创建收藏
+ * @param rawData 原始数据
+ * @param brief 简要描述
+ */
+suspend fun NapCatBotApi.createCollection(rawData: String, brief: String) {
+    apiRequestUnit("create_collection", mapOf("rawData" to rawData, "brief" to brief))
+}
+
+/**
+ * 获取AI角色列表
+ *
+ * 获取群聊中的AI角色列表
+ * @param groupId 群号
+ * @param chatType 聊天类型
+ */
+suspend fun NapCatBotApi.getAiCharacters(groupId: String, chatType: Long): NapCatExtraApiExpand.List<AiCharactersItemItem> {
+    return apiRequest("get_ai_characters", mapOf("group_id" to groupId, "chat_type" to chatType))
+}
+
+/**
+ * 获取ClientKey
+ *
+ * 获取当前登录帐号的ClientKey
+ */
+suspend fun NapCatBotApi.getClientkey(): NapCatExtraApiExpand.Clientkey {
+    return apiRequest("get_clientkey")
+}
+
+/**
+ * 图片 OCR 识别
+ *
+ * 识别图片中的文字内容(仅Windows端支持)
+ * @param image 图片路径、URL或Base64
+ */
+suspend fun NapCatBotApi.ocrImage(image: String) {
+    apiRequestUnit("ocr_image", mapOf("image" to image))
+}
+
+/**
+ * 批量踢出群成员
+ *
+ * 从指定群聊中批量踢出多个成员
+ * @param groupId 群号
+ * @param userId QQ号列表
+ * @param rejectAddRequest 是否拒绝加群请求
+ */
+suspend fun NapCatBotApi.setGroupKickMembers(groupId: String, userId: List<String>, rejectAddRequest: Boolean? = null) {
+    apiRequestUnit("set_group_kick_members", mapOf("group_id" to groupId, "user_id" to userId, "reject_add_request" to rejectAddRequest))
+}
+
+/**
+ * 设置专属头衔
+ *
+ * 设置群聊中指定成员的专属头衔
+ * @param groupId 群号
+ * @param userId QQ号
+ * @param specialTitle 专属头衔
+ */
+suspend fun NapCatBotApi.setGroupSpecialTitle(groupId: String, userId: String, specialTitle: String) {
+    apiRequestUnit("set_group_special_title", mapOf("group_id" to groupId, "user_id" to userId, "special_title" to specialTitle))
+}
+
+/**
+ * 设置QQ头像
+ *
+ * 修改当前账号的QQ头像
+ * @param file 图片路径、URL或Base64
+ */
+suspend fun NapCatBotApi.setQqAvatar(file: String) {
+    apiRequestUnit("set_qq_avatar", mapOf("file" to file))
+}
+
+/**
+ * 设置个性签名
+ *
+ * 修改当前登录帐号的个性签名
+ * @param longNick 签名内容
+ */
+suspend fun NapCatBotApi.setSelfLongnick(longNick: String) {
+    apiRequestUnit("set_self_longnick", mapOf("longNick" to longNick))
+}
+
+/**
+ * 英文单词翻译
+ *
+ * 将英文单词列表翻译为中文
+ * @param words 待翻译单词列表
+ */
+suspend fun NapCatBotApi.translateEn2zh(words: List<String>) {
+    apiRequestUnit("translate_en2zh", mapOf("words" to words))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatFileApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatFileApiExpand.kt
@@ -1,0 +1,183 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import tools.jackson.databind.JsonNode
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * NapCatFileApiExpand
+ */
+class NapCatFileApiExpand {
+    /**
+     * File
+     */
+    data class File(
+        /**
+         * 本地路径
+         */
+        @field:JsonProperty("file")
+        val file: String?,
+        /**
+         * 下载URL
+         */
+        @field:JsonProperty("url")
+        val url: String?,
+        /**
+         * 文件大小
+         */
+        @field:JsonProperty("file_size")
+        val fileSize: String?,
+        /**
+         * 文件名
+         */
+        @field:JsonProperty("file_name")
+        val fileName: String?,
+        /**
+         * Base64编码
+         */
+        @field:JsonProperty("base64")
+        val base64: String?
+    )
+
+    /**
+     * GroupFileUrl
+     */
+    data class GroupFileUrl(
+        /**
+         * 文件下载链接
+         */
+        @field:JsonProperty("url")
+        val url: String?
+    )
+
+    /**
+     * Image
+     */
+    data class Image(
+        /**
+         * 本地路径
+         */
+        @field:JsonProperty("file")
+        val file: String?,
+        /**
+         * 下载URL
+         */
+        @field:JsonProperty("url")
+        val url: String?,
+        /**
+         * 文件大小
+         */
+        @field:JsonProperty("file_size")
+        val fileSize: String?,
+        /**
+         * 文件名
+         */
+        @field:JsonProperty("file_name")
+        val fileName: String?,
+        /**
+         * Base64编码
+         */
+        @field:JsonProperty("base64")
+        val base64: String?
+    )
+
+    /**
+     * PrivateFileUrl
+     */
+    data class PrivateFileUrl(
+        /**
+         * 文件下载链接
+         */
+        @field:JsonProperty("url")
+        val url: String?
+    )
+
+    /**
+     * Record
+     */
+    data class Record(
+        /**
+         * 本地路径
+         */
+        @field:JsonProperty("file")
+        val file: String?,
+        /**
+         * 下载URL
+         */
+        @field:JsonProperty("url")
+        val url: String?,
+        /**
+         * 文件大小
+         */
+        @field:JsonProperty("file_size")
+        val fileSize: String?,
+        /**
+         * 文件名
+         */
+        @field:JsonProperty("file_name")
+        val fileName: String?,
+        /**
+         * Base64编码
+         */
+        @field:JsonProperty("base64")
+        val base64: String?
+    )
+
+}
+
+/**
+ * 获取文件
+ *
+ * 获取指定文件的详细信息及下载路径
+ * @param file 文件路径、URL或Base64
+ * @param fileId 文件ID
+ */
+suspend fun NapCatBotApi.getFile(file: String? = null, fileId: String? = null): NapCatFileApiExpand.File {
+    return apiRequest("get_file", mapOf("file" to file, "file_id" to fileId))
+}
+
+/**
+ * 获取群文件URL
+ *
+ * 获取指定群文件的下载链接
+ * @param groupId 群号
+ * @param fileId 文件ID
+ */
+suspend fun NapCatBotApi.getGroupFileUrl(groupId: String, fileId: String): NapCatFileApiExpand.GroupFileUrl {
+    return apiRequest("get_group_file_url", mapOf("group_id" to groupId, "file_id" to fileId))
+}
+
+/**
+ * 获取图片
+ *
+ * 获取指定图片的信息及路径
+ * @param file 文件路径、URL或Base64
+ * @param fileId 文件ID
+ */
+suspend fun NapCatBotApi.getImage(file: String? = null, fileId: String? = null): NapCatFileApiExpand.Image {
+    return apiRequest("get_image", mapOf("file" to file, "file_id" to fileId))
+}
+
+/**
+ * 获取私聊文件URL
+ *
+ * 获取指定私聊文件的下载链接
+ * @param fileId 文件ID
+ */
+suspend fun NapCatBotApi.getPrivateFileUrl(fileId: String): NapCatFileApiExpand.PrivateFileUrl {
+    return apiRequest("get_private_file_url", mapOf("file_id" to fileId))
+}
+
+/**
+ * 获取语音
+ *
+ * 获取指定语音文件的信息，并支持格式转换
+ * @param file 文件路径、URL或Base64
+ * @param fileId 文件ID
+ * @param outFormat 输出格式
+ */
+suspend fun NapCatBotApi.getRecord(file: String? = null, fileId: String? = null, outFormat: String): NapCatFileApiExpand.Record {
+    return apiRequest("get_record", mapOf("file" to file, "file_id" to fileId, "out_format" to outFormat))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatFileExtraExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatFileExtraExpand.kt
@@ -1,0 +1,182 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import tools.jackson.databind.JsonNode
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * NapCatFileExtraExpand
+ */
+class NapCatFileExtraExpand {
+    /**
+     * FilesetId
+     */
+    data class FilesetId(
+        /**
+         * 文件集 ID
+         */
+        @field:JsonProperty("fileset_id")
+        val filesetId: String
+    )
+
+}
+
+/**
+ * 取消在线文件
+ * @param userId 用户 QQ
+ * @param msgId 消息 ID
+ */
+suspend fun NapCatBotApi.cancelOnlineFile(userId: String, msgId: String) {
+    apiRequestUnit("cancel_online_file", mapOf("user_id" to userId, "msg_id" to msgId))
+}
+
+/**
+ * 创建闪照任务
+ * @param files 文件列表或单个文件路径
+ * @param name 任务名称
+ * @param thumbPath 缩略图路径
+ */
+suspend fun NapCatBotApi.createFlashTask(files: List<String>, name: String? = null, thumbPath: String? = null) {
+    apiRequestUnit("create_flash_task", mapOf("files" to files, "name" to name, "thumb_path" to thumbPath))
+}
+
+/**
+ * 下载文件集
+ * @param filesetId 文件集 ID
+ */
+suspend fun NapCatBotApi.downloadFileset(filesetId: String): NapCatFileExtraExpand.String {
+    return apiRequest("download_fileset", mapOf("fileset_id" to filesetId))
+}
+
+/**
+ * 获取文件集 ID
+ * @param shareCode 分享码或分享链接
+ */
+suspend fun NapCatBotApi.getFilesetId(shareCode: String): NapCatFileExtraExpand.FilesetId {
+    return apiRequest("get_fileset_id", mapOf("share_code" to shareCode))
+}
+
+/**
+ * 获取文件集信息
+ * @param filesetId 文件集 ID
+ */
+suspend fun NapCatBotApi.getFilesetInfo(filesetId: String): NapCatFileExtraExpand.String {
+    return apiRequest("get_fileset_info", mapOf("fileset_id" to filesetId))
+}
+
+/**
+ * 获取闪照文件列表
+ * @param filesetId 文件集 ID
+ */
+suspend fun NapCatBotApi.getFlashFileList(filesetId: String): NapCatFileExtraExpand.String {
+    return apiRequest("get_flash_file_list", mapOf("fileset_id" to filesetId))
+}
+
+/**
+ * 获取闪照文件链接
+ * @param filesetId 文件集 ID
+ * @param fileName 文件名
+ * @param fileIndex 文件索引
+ */
+suspend fun NapCatBotApi.getFlashFileUrl(filesetId: String, fileName: String? = null, fileIndex: Long? = null): NapCatFileExtraExpand.String {
+    return apiRequest("get_flash_file_url", mapOf("fileset_id" to filesetId, "file_name" to fileName, "file_index" to fileIndex))
+}
+
+/**
+ * 获取在线文件消息
+ * @param userId 用户 QQ
+ */
+suspend fun NapCatBotApi.getOnlineFileMsg(userId: String): NapCatFileExtraExpand.String {
+    return apiRequest("get_online_file_msg", mapOf("user_id" to userId))
+}
+
+/**
+ * 获取文件分享链接
+ * @param filesetId 文件集 ID
+ */
+suspend fun NapCatBotApi.getShareLink(filesetId: String): NapCatFileExtraExpand.String {
+    return apiRequest("get_share_link", mapOf("fileset_id" to filesetId))
+}
+
+/**
+ * 移动群文件
+ * @param groupId 群号
+ * @param fileId 文件ID
+ * @param currentParentDirectory 当前父目录
+ * @param targetParentDirectory 目标父目录
+ */
+suspend fun NapCatBotApi.moveGroupFile(groupId: String, fileId: String, currentParentDirectory: String, targetParentDirectory: String) {
+    apiRequestUnit("move_group_file", mapOf("group_id" to groupId, "file_id" to fileId, "current_parent_directory" to currentParentDirectory, "target_parent_directory" to targetParentDirectory))
+}
+
+/**
+ * 接收在线文件
+ * @param userId 用户 QQ
+ * @param msgId 消息 ID
+ * @param elementId 元素 ID
+ */
+suspend fun NapCatBotApi.receiveOnlineFile(userId: String, msgId: String, elementId: String) {
+    apiRequestUnit("receive_online_file", mapOf("user_id" to userId, "msg_id" to msgId, "element_id" to elementId))
+}
+
+/**
+ * 拒绝在线文件
+ * @param userId 用户 QQ
+ * @param msgId 消息 ID
+ * @param elementId 元素 ID
+ */
+suspend fun NapCatBotApi.refuseOnlineFile(userId: String, msgId: String, elementId: String) {
+    apiRequestUnit("refuse_online_file", mapOf("user_id" to userId, "msg_id" to msgId, "element_id" to elementId))
+}
+
+/**
+ * 重命名群文件
+ * @param groupId 群号
+ * @param fileId 文件ID
+ * @param currentParentDirectory 当前父目录
+ * @param newName 新文件名
+ */
+suspend fun NapCatBotApi.renameGroupFile(groupId: String, fileId: String, currentParentDirectory: String, newName: String) {
+    apiRequestUnit("rename_group_file", mapOf("group_id" to groupId, "file_id" to fileId, "current_parent_directory" to currentParentDirectory, "new_name" to newName))
+}
+
+/**
+ * 发送闪照消息
+ * @param filesetId 文件集 ID
+ * @param userId 用户 QQ
+ * @param groupId 群号
+ */
+suspend fun NapCatBotApi.sendFlashMsg(filesetId: String, userId: String? = null, groupId: String? = null) {
+    apiRequestUnit("send_flash_msg", mapOf("fileset_id" to filesetId, "user_id" to userId, "group_id" to groupId))
+}
+
+/**
+ * 发送在线文件
+ * @param userId 用户 QQ
+ * @param filePath 本地文件路径
+ * @param fileName 文件名 (可选)
+ */
+suspend fun NapCatBotApi.sendOnlineFile(userId: String, filePath: String, fileName: String? = null) {
+    apiRequestUnit("send_online_file", mapOf("user_id" to userId, "file_path" to filePath, "file_name" to fileName))
+}
+
+/**
+ * 发送在线文件夹
+ * @param userId 用户 QQ
+ * @param folderPath 本地文件夹路径
+ * @param folderName 文件夹名称 (可选)
+ */
+suspend fun NapCatBotApi.sendOnlineFolder(userId: String, folderPath: String, folderName: String? = null) {
+    apiRequestUnit("send_online_folder", mapOf("user_id" to userId, "folder_path" to folderPath, "folder_name" to folderName))
+}
+
+/**
+ * 传输群文件
+ * @param groupId 群号
+ * @param fileId 文件ID
+ */
+suspend fun NapCatBotApi.transGroupFile(groupId: String, fileId: String) {
+    apiRequestUnit("trans_group_file", mapOf("group_id" to groupId, "file_id" to fileId))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatGoCqHttpExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatGoCqHttpExpand.kt
@@ -1,0 +1,635 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import tools.jackson.databind.JsonNode
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * NapCatGoCqHttpExpand
+ */
+class NapCatGoCqHttpExpand {
+    /**
+     * ModelShowItemItemVariants
+     */
+    data class ModelShowItemItemVariants(
+        /**
+         * 显示名称
+         */
+        @field:JsonProperty("model_show")
+        val modelShow: String,
+        /**
+         * 是否需要付费
+         */
+        @field:JsonProperty("need_pay")
+        val needPay: Boolean
+    )
+
+    /**
+     * ModelShowItemItem
+     */
+    data class ModelShowItemItem(
+        /**
+         * variants
+         */
+        @field:JsonProperty("variants")
+        val variants: ModelShowItemItemVariants
+    )
+
+    /**
+     * CheckUrlSafely
+     */
+    data class CheckUrlSafely(
+        /**
+         * 安全等级 (1: 安全, 2: 未知, 3: 危险)
+         */
+        @field:JsonProperty("level")
+        val level: Long
+    )
+
+    /**
+     * DownloadFile
+     */
+    data class DownloadFile(
+        /**
+         * 文件路径
+         */
+        @field:JsonProperty("file")
+        val file: String
+    )
+
+    /**
+     * ForwardMsg
+     */
+    data class ForwardMsg(
+        /**
+         * 消息列表
+         */
+        @field:JsonProperty("messages")
+        val messages: List<String>?
+    )
+
+    /**
+     * FriendMsgHistory
+     */
+    data class FriendMsgHistory(
+        /**
+         * 消息列表
+         */
+        @field:JsonProperty("messages")
+        val messages: List<String>
+    )
+
+    /**
+     * GroupAtAllRemain
+     */
+    data class GroupAtAllRemain(
+        /**
+         * 是否可以艾特全体
+         */
+        @field:JsonProperty("can_at_all")
+        val canAtAll: Boolean,
+        /**
+         * 群艾特全体剩余次数
+         */
+        @field:JsonProperty("remain_at_all_count_for_group")
+        val remainAtAllCountForGroup: Long,
+        /**
+         * 个人艾特全体剩余次数
+         */
+        @field:JsonProperty("remain_at_all_count_for_uin")
+        val remainAtAllCountForUin: Long
+    )
+
+    /**
+     * GroupFileSystemInfo
+     */
+    data class GroupFileSystemInfo(
+        /**
+         * 文件总数
+         */
+        @field:JsonProperty("file_count")
+        val fileCount: Long,
+        /**
+         * 文件上限
+         */
+        @field:JsonProperty("limit_count")
+        val limitCount: Long,
+        /**
+         * 已使用空间
+         */
+        @field:JsonProperty("used_space")
+        val usedSpace: Long,
+        /**
+         * 总空间
+         */
+        @field:JsonProperty("total_space")
+        val totalSpace: Long
+    )
+
+    /**
+     * GroupFilesByFolder
+     */
+    data class GroupFilesByFolder(
+        /**
+         * 文件列表
+         */
+        @field:JsonProperty("files")
+        val files: List<String>,
+        /**
+         * 文件夹列表
+         */
+        @field:JsonProperty("folders")
+        val folders: List<String>
+    )
+
+    /**
+     * GroupHonorInfo
+     */
+    data class GroupHonorInfo(
+        /**
+         * 群号
+         */
+        @field:JsonProperty("group_id")
+        val groupId: Long,
+        /**
+         * 当前龙王
+         */
+        @field:JsonProperty("current_talkative")
+        val currentTalkative: JsonNode,
+        /**
+         * 龙王列表
+         */
+        @field:JsonProperty("talkative_list")
+        val talkativeList: List<String>,
+        /**
+         * 群聊之火列表
+         */
+        @field:JsonProperty("performer_list")
+        val performerList: List<String>,
+        /**
+         * 群聊炽热列表
+         */
+        @field:JsonProperty("legend_list")
+        val legendList: List<String>,
+        /**
+         * 快乐源泉列表
+         */
+        @field:JsonProperty("emotion_list")
+        val emotionList: List<String>,
+        /**
+         * 冒尖小春笋列表
+         */
+        @field:JsonProperty("strong_newbie_list")
+        val strongNewbieList: List<String>
+    )
+
+    /**
+     * GroupMsgHistory
+     */
+    data class GroupMsgHistory(
+        /**
+         * 消息列表
+         */
+        @field:JsonProperty("messages")
+        val messages: List<String>
+    )
+
+    /**
+     * GroupRootFiles
+     */
+    data class GroupRootFiles(
+        /**
+         * 文件列表
+         */
+        @field:JsonProperty("files")
+        val files: List<String>,
+        /**
+         * 文件夹列表
+         */
+        @field:JsonProperty("folders")
+        val folders: List<String>
+    )
+
+    /**
+     * StrangerInfo
+     */
+    data class StrangerInfo(
+        /**
+         * 用户QQ
+         */
+        @field:JsonProperty("user_id")
+        val userId: Long,
+        /**
+         * UID
+         */
+        @field:JsonProperty("uid")
+        val uid: String,
+        /**
+         * 昵称
+         */
+        @field:JsonProperty("nickname")
+        val nickname: String,
+        /**
+         * 年龄
+         */
+        @field:JsonProperty("age")
+        val age: Long,
+        /**
+         * QID
+         */
+        @field:JsonProperty("qid")
+        val qid: String,
+        /**
+         * QQ等级
+         */
+        @field:JsonProperty("qqLevel")
+        val qqLevel: Long,
+        /**
+         * 性别
+         */
+        @field:JsonProperty("sex")
+        val sex: String,
+        /**
+         * 个性签名
+         */
+        @field:JsonProperty("long_nick")
+        val longNick: String,
+        /**
+         * 注册时间
+         */
+        @field:JsonProperty("reg_time")
+        val regTime: Long,
+        /**
+         * 是否VIP
+         */
+        @field:JsonProperty("is_vip")
+        val isVip: Boolean,
+        /**
+         * 是否年费VIP
+         */
+        @field:JsonProperty("is_years_vip")
+        val isYearsVip: Boolean,
+        /**
+         * VIP等级
+         */
+        @field:JsonProperty("vip_level")
+        val vipLevel: Long,
+        /**
+         * 备注
+         */
+        @field:JsonProperty("remark")
+        val remark: String,
+        /**
+         * 状态
+         */
+        @field:JsonProperty("status")
+        val status: Long,
+        /**
+         * 登录天数
+         */
+        @field:JsonProperty("login_days")
+        val loginDays: Long
+    )
+
+}
+
+/**
+ * 处理快速操作
+ *
+ * 处理来自事件上报的快速操作请求
+ * @param context 事件上下文
+ * @param operation 快速操作内容
+ */
+suspend fun NapCatBotApi..handleQuickOperation(context: Context, operation: Operation) {
+    apiRequestUnit(".handle_quick_operation", mapOf("context" to context, "operation" to operation))
+}
+
+/**
+ * 获取机型显示
+ *
+ * 获取当前账号可用的设备机型显示名称列表
+ * @param model 模型名称
+ */
+suspend fun NapCatBotApi.getModelShow(model: String? = null): NapCatGoCqHttpExpand.List<ModelShowItemItem> {
+    return apiRequest("_get_model_show", mapOf("model" to model))
+}
+
+/**
+ * 发送群公告
+ *
+ * 在指定群聊中发布新的公告
+ * @param groupId 群号
+ * @param content 公告内容
+ * @param image 公告图片路径或 URL
+ * @param pinned 是否置顶 (0/1)
+ * @param type 类型 (默认为 1)
+ * @param confirmRequired 是否需要确认 (0/1)
+ * @param isShowEditCard 是否显示修改群名片引导 (0/1)
+ * @param tipWindowType 弹窗类型 (默认为 0)
+ */
+suspend fun NapCatBotApi.sendGroupNotice(groupId: String, content: String, image: String? = null, pinned: Long, type: Long, confirmRequired: Long, isShowEditCard: Long, tipWindowType: Long) {
+    apiRequestUnit("_send_group_notice", mapOf("group_id" to groupId, "content" to content, "image" to image, "pinned" to pinned, "type" to type, "confirm_required" to confirmRequired, "is_show_edit_card" to isShowEditCard, "tip_window_type" to tipWindowType))
+}
+
+/**
+ * 设置机型
+ *
+ * 设置当前账号的设备机型名称
+ */
+suspend fun NapCatBotApi.setModelShow() {
+    apiRequestUnit("_set_model_show")
+}
+
+/**
+ * 检查URL安全性
+ *
+ * 检查指定URL的安全等级
+ * @param url 要检查的 URL
+ */
+suspend fun NapCatBotApi.checkUrlSafely(url: String): NapCatGoCqHttpExpand.CheckUrlSafely {
+    return apiRequest("check_url_safely", mapOf("url" to url))
+}
+
+/**
+ * 创建群文件目录
+ *
+ * 在群文件系统中创建新的文件夹
+ * @param groupId 群号
+ * @param folderName 文件夹名称
+ * @param name 文件夹名称
+ */
+suspend fun NapCatBotApi.createGroupFileFolder(groupId: String, folderName: String? = null, name: String? = null) {
+    apiRequestUnit("create_group_file_folder", mapOf("group_id" to groupId, "folder_name" to folderName, "name" to name))
+}
+
+/**
+ * 删除好友
+ *
+ * 从好友列表中删除指定用户
+ * @param friendId 好友 QQ 号
+ * @param userId 用户 QQ 号
+ * @param tempBlock 是否加入黑名单
+ * @param tempBothDel 是否双向删除
+ */
+suspend fun NapCatBotApi.deleteFriend(friendId: String? = null, userId: String? = null, tempBlock: Boolean? = null, tempBothDel: Boolean? = null) {
+    apiRequestUnit("delete_friend", mapOf("friend_id" to friendId, "user_id" to userId, "temp_block" to tempBlock, "temp_both_del" to tempBothDel))
+}
+
+/**
+ * 删除群文件
+ *
+ * 在群文件系统中删除指定的文件
+ * @param groupId 群号
+ * @param fileId 文件ID
+ */
+suspend fun NapCatBotApi.deleteGroupFile(groupId: String, fileId: String) {
+    apiRequestUnit("delete_group_file", mapOf("group_id" to groupId, "file_id" to fileId))
+}
+
+/**
+ * 删除群文件目录
+ *
+ * 在群文件系统中删除指定的文件夹
+ * @param groupId 群号
+ * @param folderId 文件夹ID
+ * @param folder 文件夹ID
+ */
+suspend fun NapCatBotApi.deleteGroupFolder(groupId: String, folderId: String? = null, folder: String? = null) {
+    apiRequestUnit("delete_group_folder", mapOf("group_id" to groupId, "folder_id" to folderId, "folder" to folder))
+}
+
+/**
+ * 下载文件
+ *
+ * 下载网络文件到本地临时目录
+ * @param url 下载链接
+ * @param base64 base64数据
+ * @param name 文件名
+ * @param headers 请求头
+ */
+suspend fun NapCatBotApi.downloadFile(url: String? = null, base64: String? = null, name: String? = null, headers: String? = null): NapCatGoCqHttpExpand.DownloadFile {
+    return apiRequest("download_file", mapOf("url" to url, "base64" to base64, "name" to name, "headers" to headers))
+}
+
+/**
+ * 获取合并转发消息
+ *
+ * 获取合并转发消息的具体内容
+ * @param messageId 消息ID
+ * @param id 消息ID
+ */
+suspend fun NapCatBotApi.getForwardMsg(messageId: String? = null, id: String? = null): NapCatGoCqHttpExpand.ForwardMsg {
+    return apiRequest("get_forward_msg", mapOf("message_id" to messageId, "id" to id))
+}
+
+/**
+ * 获取好友历史消息
+ *
+ * 获取指定好友的历史聊天记录
+ * @param userId 用户QQ
+ * @param messageSeq 起始消息序号
+ * @param count 获取消息数量
+ * @param reverseOrder 是否反向排序
+ * @param disableGetUrl 是否禁用获取URL
+ * @param parseMultMsg 是否解析合并消息
+ * @param quickReply 是否快速回复
+ * @param reverseOrder 是否反向排序(旧版本兼容)
+ */
+suspend fun NapCatBotApi.getFriendMsgHistory(userId: String, messageSeq: String? = null, count: Long, reverseOrder: Boolean, disableGetUrl: Boolean, parseMultMsg: Boolean, quickReply: Boolean, reverseOrder: Boolean): NapCatGoCqHttpExpand.FriendMsgHistory {
+    return apiRequest("get_friend_msg_history", mapOf("user_id" to userId, "message_seq" to messageSeq, "count" to count, "reverse_order" to reverseOrder, "disable_get_url" to disableGetUrl, "parse_mult_msg" to parseMultMsg, "quick_reply" to quickReply, "reverseOrder" to reverseOrder))
+}
+
+/**
+ * 获取群艾特全体剩余次数
+ *
+ * 获取指定群聊中艾特全体成员的剩余次数
+ * @param groupId 群号
+ */
+suspend fun NapCatBotApi.getGroupAtAllRemain(groupId: String): NapCatGoCqHttpExpand.GroupAtAllRemain {
+    return apiRequest("get_group_at_all_remain", mapOf("group_id" to groupId))
+}
+
+/**
+ * 获取群文件系统信息
+ *
+ * 获取群聊文件系统的空间及状态信息
+ * @param groupId 群号
+ */
+suspend fun NapCatBotApi.getGroupFileSystemInfo(groupId: String): NapCatGoCqHttpExpand.GroupFileSystemInfo {
+    return apiRequest("get_group_file_system_info", mapOf("group_id" to groupId))
+}
+
+/**
+ * 获取群文件夹文件列表
+ *
+ * 获取指定群文件夹下的文件及子文件夹列表
+ * @param groupId 群号
+ * @param folderId 文件夹ID
+ * @param folder 文件夹ID
+ * @param fileCount 文件数量
+ */
+suspend fun NapCatBotApi.getGroupFilesByFolder(groupId: String, folderId: String? = null, folder: String? = null, fileCount: Long): NapCatGoCqHttpExpand.GroupFilesByFolder {
+    return apiRequest("get_group_files_by_folder", mapOf("group_id" to groupId, "folder_id" to folderId, "folder" to folder, "file_count" to fileCount))
+}
+
+/**
+ * 获取群荣誉信息
+ *
+ * 获取指定群聊的荣誉信息，如龙王等
+ * @param groupId 群号
+ * @param type 荣誉类型
+ */
+suspend fun NapCatBotApi.getGroupHonorInfo(groupId: String, type: String? = null): NapCatGoCqHttpExpand.GroupHonorInfo {
+    return apiRequest("get_group_honor_info", mapOf("group_id" to groupId, "type" to type))
+}
+
+/**
+ * 获取群历史消息
+ *
+ * 获取指定群聊的历史聊天记录
+ * @param groupId 群号
+ * @param messageSeq 起始消息序号
+ * @param count 获取消息数量
+ * @param reverseOrder 是否反向排序
+ * @param disableGetUrl 是否禁用获取URL
+ * @param parseMultMsg 是否解析合并消息
+ * @param quickReply 是否快速回复
+ * @param reverseOrder 是否反向排序(旧版本兼容)
+ */
+suspend fun NapCatBotApi.getGroupMsgHistory(groupId: String, messageSeq: String? = null, count: Long, reverseOrder: Boolean, disableGetUrl: Boolean, parseMultMsg: Boolean, quickReply: Boolean, reverseOrder: Boolean): NapCatGoCqHttpExpand.GroupMsgHistory {
+    return apiRequest("get_group_msg_history", mapOf("group_id" to groupId, "message_seq" to messageSeq, "count" to count, "reverse_order" to reverseOrder, "disable_get_url" to disableGetUrl, "parse_mult_msg" to parseMultMsg, "quick_reply" to quickReply, "reverseOrder" to reverseOrder))
+}
+
+/**
+ * 获取群根目录文件列表
+ *
+ * 获取群文件根目录下的所有文件和文件夹
+ * @param groupId 群号
+ * @param fileCount 文件数量
+ */
+suspend fun NapCatBotApi.getGroupRootFiles(groupId: String, fileCount: Long): NapCatGoCqHttpExpand.GroupRootFiles {
+    return apiRequest("get_group_root_files", mapOf("group_id" to groupId, "file_count" to fileCount))
+}
+
+/**
+ * 获取在线客户端
+ *
+ * 获取当前登录账号的在线客户端列表
+ */
+suspend fun NapCatBotApi.getOnlineClients(): NapCatGoCqHttpExpand.List<String> {
+    return apiRequest("get_online_clients")
+}
+
+/**
+ * 获取陌生人信息
+ *
+ * 获取指定非好友用户的信息
+ * @param userId 用户QQ
+ * @param noCache 是否不使用缓存
+ */
+suspend fun NapCatBotApi.getStrangerInfo(userId: String, noCache: Boolean): NapCatGoCqHttpExpand.StrangerInfo {
+    return apiRequest("get_stranger_info", mapOf("user_id" to userId, "no_cache" to noCache))
+}
+
+/**
+ * 发送合并转发消息
+ *
+ * 发送合并转发消息
+ * @param messageType 消息类型 (private/group)
+ * @param userId 用户QQ
+ * @param groupId 群号
+ * @param message OneBot 11 消息混合类型
+ * @param autoEscape 是否作为纯文本发送
+ * @param source 合并转发来源
+ * @param news 合并转发新闻
+ * @param summary 合并转发摘要
+ * @param prompt 合并转发提示
+ */
+suspend fun NapCatBotApi.sendForwardMsg(messageType: String? = null, userId: String? = null, groupId: String? = null, message: List<MessageItem>, autoEscape: Boolean? = null, source: String? = null, news: List<NewsItem>? = null, summary: String? = null, prompt: String? = null) {
+    apiRequestUnit("send_forward_msg", mapOf("message_type" to messageType, "user_id" to userId, "group_id" to groupId, "message" to message, "auto_escape" to autoEscape, "source" to source, "news" to news, "summary" to summary, "prompt" to prompt))
+}
+
+/**
+ * 发送群合并转发消息
+ * @param messageType 消息类型 (private/group)
+ * @param userId 用户QQ
+ * @param groupId 群号
+ * @param message OneBot 11 消息混合类型
+ * @param autoEscape 是否作为纯文本发送
+ * @param source 合并转发来源
+ * @param news 合并转发新闻
+ * @param summary 合并转发摘要
+ * @param prompt 合并转发提示
+ */
+suspend fun NapCatBotApi.sendGroupForwardMsg(messageType: String? = null, userId: String? = null, groupId: String? = null, message: List<MessageItem>, autoEscape: Boolean? = null, source: String? = null, news: List<NewsItem>? = null, summary: String? = null, prompt: String? = null) {
+    apiRequestUnit("send_group_forward_msg", mapOf("message_type" to messageType, "user_id" to userId, "group_id" to groupId, "message" to message, "auto_escape" to autoEscape, "source" to source, "news" to news, "summary" to summary, "prompt" to prompt))
+}
+
+/**
+ * 发送私聊合并转发消息
+ * @param messageType 消息类型 (private/group)
+ * @param userId 用户QQ
+ * @param groupId 群号
+ * @param message OneBot 11 消息混合类型
+ * @param autoEscape 是否作为纯文本发送
+ * @param source 合并转发来源
+ * @param news 合并转发新闻
+ * @param summary 合并转发摘要
+ * @param prompt 合并转发提示
+ */
+suspend fun NapCatBotApi.sendPrivateForwardMsg(messageType: String? = null, userId: String? = null, groupId: String? = null, message: List<MessageItem>, autoEscape: Boolean? = null, source: String? = null, news: List<NewsItem>? = null, summary: String? = null, prompt: String? = null) {
+    apiRequestUnit("send_private_forward_msg", mapOf("message_type" to messageType, "user_id" to userId, "group_id" to groupId, "message" to message, "auto_escape" to autoEscape, "source" to source, "news" to news, "summary" to summary, "prompt" to prompt))
+}
+
+/**
+ * 设置群头像
+ *
+ * 修改指定群聊的头像
+ * @param file 头像文件路径或 URL
+ * @param groupId 群号
+ */
+suspend fun NapCatBotApi.setGroupPortrait(file: String, groupId: String) {
+    apiRequestUnit("set_group_portrait", mapOf("file" to file, "group_id" to groupId))
+}
+
+/**
+ * 设置QQ资料
+ *
+ * 修改当前账号的昵称、个性签名等资料
+ * @param nickname 昵称
+ * @param personalNote 个性签名
+ * @param sex 性别 (0: 未知, 1: 男, 2: 女)
+ */
+suspend fun NapCatBotApi.setQqProfile(nickname: String, personalNote: String? = null, sex: Long? = null) {
+    apiRequestUnit("set_qq_profile", mapOf("nickname" to nickname, "personal_note" to personalNote, "sex" to sex))
+}
+
+/**
+ * 上传群文件
+ *
+ * 上传资源路径或URL指定的文件到指定群聊的文件系统中
+ * @param groupId 群号
+ * @param file 资源路径或URL
+ * @param name 文件名
+ * @param folder 父目录 ID
+ * @param folderId 父目录 ID (兼容性字段)
+ * @param uploadFile 是否执行上传
+ */
+suspend fun NapCatBotApi.uploadGroupFile(groupId: String, file: String, name: String, folder: String? = null, folderId: String? = null, uploadFile: Boolean) {
+    apiRequestUnit("upload_group_file", mapOf("group_id" to groupId, "file" to file, "name" to name, "folder" to folder, "folder_id" to folderId, "upload_file" to uploadFile))
+}
+
+/**
+ * 上传私聊文件
+ *
+ * 上传本地文件到指定私聊会话中
+ * @param userId 用户 QQ
+ * @param file 资源路径或URL
+ * @param name 文件名
+ * @param uploadFile 是否执行上传
+ */
+suspend fun NapCatBotApi.uploadPrivateFile(userId: String, file: String, name: String, uploadFile: Boolean) {
+    apiRequestUnit("upload_private_file", mapOf("user_id" to userId, "file" to file, "name" to name, "upload_file" to uploadFile))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatGroupApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatGroupApiExpand.kt
@@ -1,0 +1,627 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import tools.jackson.databind.JsonNode
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * NapCatGroupApiExpand
+ */
+class NapCatGroupApiExpand {
+    /**
+     * GroupNoticeItemItemMessage
+     */
+    data class GroupNoticeItemItemMessage(
+        /**
+         * 文本内容
+         */
+        @field:JsonProperty("text")
+        val text: String,
+        /**
+         * 图片列表
+         */
+        @field:JsonProperty("image")
+        val image: List<String>,
+        /**
+         * 图片列表
+         */
+        @field:JsonProperty("images")
+        val images: List<String>
+    )
+
+    /**
+     * GroupNoticeItemItem
+     */
+    data class GroupNoticeItemItem(
+        /**
+         * 发送者QQ
+         */
+        @field:JsonProperty("sender_id")
+        val senderId: Long,
+        /**
+         * 发布时间
+         */
+        @field:JsonProperty("publish_time")
+        val publishTime: Long,
+        /**
+         * 公告ID
+         */
+        @field:JsonProperty("notice_id")
+        val noticeId: String,
+        /**
+         * 公告内容
+         */
+        @field:JsonProperty("message")
+        val message: GroupNoticeItemItemMessage,
+        /**
+         * settings
+         */
+        @field:JsonProperty("settings")
+        val settings: String?,
+        /**
+         * 阅读数
+         */
+        @field:JsonProperty("read_num")
+        val readNum: Long?
+    )
+
+    /**
+     * EssenceMsgItem
+     */
+    data class EssenceMsgItem(
+        /**
+         * 消息序号
+         */
+        @field:JsonProperty("msg_seq")
+        val msgSeq: Long,
+        /**
+         * 消息随机数
+         */
+        @field:JsonProperty("msg_random")
+        val msgRandom: Long,
+        /**
+         * 发送者QQ
+         */
+        @field:JsonProperty("sender_id")
+        val senderId: Long,
+        /**
+         * 发送者昵称
+         */
+        @field:JsonProperty("sender_nick")
+        val senderNick: String,
+        /**
+         * 操作者QQ
+         */
+        @field:JsonProperty("operator_id")
+        val operatorId: Long,
+        /**
+         * 操作者昵称
+         */
+        @field:JsonProperty("operator_nick")
+        val operatorNick: String,
+        /**
+         * 消息ID
+         */
+        @field:JsonProperty("message_id")
+        val messageId: Long,
+        /**
+         * 操作时间
+         */
+        @field:JsonProperty("operator_time")
+        val operatorTime: Long,
+        /**
+         * 消息内容
+         */
+        @field:JsonProperty("content")
+        val content: List<String>
+    )
+
+    /**
+     * GroupDetailInfo
+     */
+    data class GroupDetailInfo(
+        /**
+         * 群号
+         */
+        @field:JsonProperty("group_id")
+        val groupId: Long,
+        /**
+         * 群名称
+         */
+        @field:JsonProperty("group_name")
+        val groupName: String,
+        /**
+         * 成员数量
+         */
+        @field:JsonProperty("member_count")
+        val memberCount: Long,
+        /**
+         * 最大成员数量
+         */
+        @field:JsonProperty("max_member_count")
+        val maxMemberCount: Long,
+        /**
+         * 全员禁言状态
+         */
+        @field:JsonProperty("group_all_shut")
+        val groupAllShut: Long,
+        /**
+         * 群备注
+         */
+        @field:JsonProperty("group_remark")
+        val groupRemark: String
+    )
+
+    /**
+     * GroupIgnoreAddRequestItemItem
+     */
+    data class GroupIgnoreAddRequestItemItem(
+        /**
+         * 请求ID
+         */
+        @field:JsonProperty("request_id")
+        val requestId: Long,
+        /**
+         * 邀请者QQ
+         */
+        @field:JsonProperty("invitor_uin")
+        val invitorUin: Long,
+        /**
+         * 邀请者昵称
+         */
+        @field:JsonProperty("invitor_nick")
+        val invitorNick: String?,
+        /**
+         * 群号
+         */
+        @field:JsonProperty("group_id")
+        val groupId: Long,
+        /**
+         * 验证信息
+         */
+        @field:JsonProperty("message")
+        val message: String?,
+        /**
+         * 群名称
+         */
+        @field:JsonProperty("group_name")
+        val groupName: String?,
+        /**
+         * 是否已处理
+         */
+        @field:JsonProperty("checked")
+        val checked: Boolean,
+        /**
+         * 处理者QQ
+         */
+        @field:JsonProperty("actor")
+        val actor: Long,
+        /**
+         * 请求者昵称
+         */
+        @field:JsonProperty("requester_nick")
+        val requesterNick: String?
+    )
+
+    /**
+     * GroupIgnoredNotifies
+     */
+    data class GroupIgnoredNotifies(
+        /**
+         * 邀请请求列表
+         */
+        @field:JsonProperty("invited_requests")
+        val invitedRequests: List<String>,
+        /**
+         * 邀请请求列表
+         */
+        @field:JsonProperty("InvitedRequest")
+        val InvitedRequest: List<String>,
+        /**
+         * 加入请求列表
+         */
+        @field:JsonProperty("join_requests")
+        val joinRequests: List<String>
+    )
+
+    /**
+     * GroupInfo
+     */
+    data class GroupInfo(
+        /**
+         * 是否全员禁言
+         */
+        @field:JsonProperty("group_all_shut")
+        val groupAllShut: Long,
+        /**
+         * 群备注
+         */
+        @field:JsonProperty("group_remark")
+        val groupRemark: String,
+        /**
+         * 群号
+         */
+        @field:JsonProperty("group_id")
+        val groupId: Long,
+        /**
+         * 群名称
+         */
+        @field:JsonProperty("group_name")
+        val groupName: String,
+        /**
+         * 成员人数
+         */
+        @field:JsonProperty("member_count")
+        val memberCount: Long?,
+        /**
+         * 最大成员人数
+         */
+        @field:JsonProperty("max_member_count")
+        val maxMemberCount: Long?
+    )
+
+    /**
+     * GroupItem
+     */
+    data class GroupItem(
+        /**
+         * 是否全员禁言
+         */
+        @field:JsonProperty("group_all_shut")
+        val groupAllShut: Long,
+        /**
+         * 群备注
+         */
+        @field:JsonProperty("group_remark")
+        val groupRemark: String,
+        /**
+         * 群号
+         */
+        @field:JsonProperty("group_id")
+        val groupId: Long,
+        /**
+         * 群名称
+         */
+        @field:JsonProperty("group_name")
+        val groupName: String,
+        /**
+         * 成员人数
+         */
+        @field:JsonProperty("member_count")
+        val memberCount: Long?,
+        /**
+         * 最大成员人数
+         */
+        @field:JsonProperty("max_member_count")
+        val maxMemberCount: Long?
+    )
+
+    /**
+     * GroupMemberInfo
+     */
+    data class GroupMemberInfo(
+        /**
+         * 群号
+         */
+        @field:JsonProperty("group_id")
+        val groupId: Long,
+        /**
+         * QQ号
+         */
+        @field:JsonProperty("user_id")
+        val userId: Long,
+        /**
+         * 昵称
+         */
+        @field:JsonProperty("nickname")
+        val nickname: String,
+        /**
+         * 名片
+         */
+        @field:JsonProperty("card")
+        val card: String?,
+        /**
+         * 性别
+         */
+        @field:JsonProperty("sex")
+        val sex: String?,
+        /**
+         * 年龄
+         */
+        @field:JsonProperty("age")
+        val age: Long?,
+        /**
+         * 入群时间戳
+         */
+        @field:JsonProperty("join_time")
+        val joinTime: Long?,
+        /**
+         * 最后发言时间戳
+         */
+        @field:JsonProperty("last_sent_time")
+        val lastSentTime: Long?,
+        /**
+         * 等级
+         */
+        @field:JsonProperty("level")
+        val level: String?,
+        /**
+         * QQ等级
+         */
+        @field:JsonProperty("qq_level")
+        val qqLevel: Long?,
+        /**
+         * 角色 (owner/admin/member)
+         */
+        @field:JsonProperty("role")
+        val role: String?,
+        /**
+         * 头衔
+         */
+        @field:JsonProperty("title")
+        val title: String?,
+        /**
+         * 地区
+         */
+        @field:JsonProperty("area")
+        val area: String?,
+        /**
+         * 是否不良记录
+         */
+        @field:JsonProperty("unfriendly")
+        val unfriendly: Boolean?,
+        /**
+         * 头衔过期时间
+         */
+        @field:JsonProperty("title_expire_time")
+        val titleExpireTime: Long?,
+        /**
+         * 是否允许修改名片
+         */
+        @field:JsonProperty("card_changeable")
+        val cardChangeable: Boolean?,
+        /**
+         * 禁言截止时间戳
+         */
+        @field:JsonProperty("shut_up_timestamp")
+        val shutUpTimestamp: Long?,
+        /**
+         * 是否为机器人
+         */
+        @field:JsonProperty("is_robot")
+        val isRobot: Boolean?,
+        /**
+         * Q龄
+         */
+        @field:JsonProperty("qage")
+        val qage: Long?
+    )
+
+}
+
+/**
+ * 删除群公告
+ *
+ * 删除群聊中的公告
+ * @param groupId 群号
+ * @param noticeId 公告ID
+ */
+suspend fun NapCatBotApi.delGroupNotice(groupId: String, noticeId: String) {
+    apiRequestUnit("_del_group_notice", mapOf("group_id" to groupId, "notice_id" to noticeId))
+}
+
+/**
+ * 获取群公告
+ *
+ * 获取指定群聊中的公告列表
+ * @param groupId 群号
+ */
+suspend fun NapCatBotApi.getGroupNotice(groupId: String): NapCatGroupApiExpand.List<GroupNoticeItemItem> {
+    return apiRequest("_get_group_notice", mapOf("group_id" to groupId))
+}
+
+/**
+ * 移出精华消息
+ *
+ * 将一条消息从群精华消息列表中移出
+ * @param messageId 消息ID
+ * @param msgSeq 消息序号
+ * @param msgRandom 消息随机数
+ * @param groupId 群号
+ */
+suspend fun NapCatBotApi.deleteEssenceMsg(messageId: Long? = null, msgSeq: String? = null, msgRandom: String? = null, groupId: String? = null) {
+    apiRequestUnit("delete_essence_msg", mapOf("message_id" to messageId, "msg_seq" to msgSeq, "msg_random" to msgRandom, "group_id" to groupId))
+}
+
+/**
+ * 获取群精华消息
+ *
+ * 获取指定群聊中的精华消息列表
+ * @param groupId 群号
+ */
+suspend fun NapCatBotApi.getEssenceMsgList(groupId: String): NapCatGroupApiExpand.List<EssenceMsgItem> {
+    return apiRequest("get_essence_msg_list", mapOf("group_id" to groupId))
+}
+
+/**
+ * 获取群详细信息
+ *
+ * 获取群聊的详细信息，包括成员数、最大成员数等
+ * @param groupId 群号
+ */
+suspend fun NapCatBotApi.getGroupDetailInfo(groupId: String): NapCatGroupApiExpand.GroupDetailInfo {
+    return apiRequest("get_group_detail_info", mapOf("group_id" to groupId))
+}
+
+/**
+ * 获取群被忽略的加群请求
+ */
+suspend fun NapCatBotApi.getGroupIgnoreAddRequest(): NapCatGroupApiExpand.List<GroupIgnoreAddRequestItemItem> {
+    return apiRequest("get_group_ignore_add_request")
+}
+
+/**
+ * 获取群忽略通知
+ *
+ * 获取被忽略的入群申请和邀请通知
+ */
+suspend fun NapCatBotApi.getGroupIgnoredNotifies(): NapCatGroupApiExpand.GroupIgnoredNotifies {
+    return apiRequest("get_group_ignored_notifies")
+}
+
+/**
+ * 获取群信息
+ *
+ * 获取群聊的基本信息
+ * @param groupId 群号
+ */
+suspend fun NapCatBotApi.getGroupInfo(groupId: String): NapCatGroupApiExpand.GroupInfo {
+    return apiRequest("get_group_info", mapOf("group_id" to groupId))
+}
+
+/**
+ * 获取群列表
+ *
+ * 获取当前帐号的群聊列表
+ * @param noCache 是否不使用缓存
+ */
+suspend fun NapCatBotApi.getGroupList(noCache: Boolean? = null): NapCatGroupApiExpand.List<GroupItem> {
+    return apiRequest("get_group_list", mapOf("no_cache" to noCache))
+}
+
+/**
+ * 获取群成员信息
+ *
+ * 获取群聊中指定成员的信息
+ * @param groupId 群号
+ * @param userId QQ号
+ * @param noCache 是否不使用缓存
+ */
+suspend fun NapCatBotApi.getGroupMemberInfo(groupId: String, userId: String, noCache: Boolean? = null): NapCatGroupApiExpand.GroupMemberInfo {
+    return apiRequest("get_group_member_info", mapOf("group_id" to groupId, "user_id" to userId, "no_cache" to noCache))
+}
+
+/**
+ * 获取群成员列表
+ *
+ * 获取群聊中的所有成员列表
+ * @param groupId 群号
+ * @param noCache 是否不使用缓存
+ */
+suspend fun NapCatBotApi.getGroupMemberList(groupId: String, noCache: Boolean? = null): NapCatGroupApiExpand.List<String> {
+    return apiRequest("get_group_member_list", mapOf("group_id" to groupId, "no_cache" to noCache))
+}
+
+/**
+ * 获取群禁言列表
+ * @param groupId 群号
+ */
+suspend fun NapCatBotApi.getGroupShutList(groupId: String): NapCatGroupApiExpand.List<String> {
+    return apiRequest("get_group_shut_list", mapOf("group_id" to groupId))
+}
+
+/**
+ * 设置精华消息
+ *
+ * 将一条消息设置为群精华消息
+ * @param messageId 消息ID
+ */
+suspend fun NapCatBotApi.setEssenceMsg(messageId: Long) {
+    apiRequestUnit("set_essence_msg", mapOf("message_id" to messageId))
+}
+
+/**
+ * 处理加群请求
+ *
+ * 同意或拒绝加群请求或邀请
+ * @param flag 请求flag
+ * @param approve 是否同意
+ * @param reason 拒绝理由
+ * @param count 搜索通知数量
+ */
+suspend fun NapCatBotApi.setGroupAddRequest(flag: String, approve: Boolean? = null, reason: String? = null, count: Long? = null) {
+    apiRequestUnit("set_group_add_request", mapOf("flag" to flag, "approve" to approve, "reason" to reason, "count" to count))
+}
+
+/**
+ * 设置群管理员
+ *
+ * 设置或取消群聊中的管理员
+ * @param groupId 群号
+ * @param userId 用户QQ
+ * @param enable 是否设置为管理员
+ */
+suspend fun NapCatBotApi.setGroupAdmin(groupId: String, userId: String, enable: Boolean? = null) {
+    apiRequestUnit("set_group_admin", mapOf("group_id" to groupId, "user_id" to userId, "enable" to enable))
+}
+
+/**
+ * 群组禁言
+ *
+ * 禁言群聊中的指定成员
+ * @param groupId 群号
+ * @param userId 用户QQ
+ * @param duration 禁言时长(秒)
+ */
+suspend fun NapCatBotApi.setGroupBan(groupId: String, userId: String, duration: Long) {
+    apiRequestUnit("set_group_ban", mapOf("group_id" to groupId, "user_id" to userId, "duration" to duration))
+}
+
+/**
+ * 设置群名片
+ *
+ * 设置群聊中指定成员的群名片
+ * @param groupId 群号
+ * @param userId 用户QQ
+ * @param card 群名片
+ */
+suspend fun NapCatBotApi.setGroupCard(groupId: String, userId: String, card: String? = null) {
+    apiRequestUnit("set_group_card", mapOf("group_id" to groupId, "user_id" to userId, "card" to card))
+}
+
+/**
+ * 群组踢人
+ *
+ * 将指定成员踢出群聊
+ * @param groupId 群号
+ * @param userId 用户QQ
+ * @param rejectAddRequest 是否拒绝加群请求
+ */
+suspend fun NapCatBotApi.setGroupKick(groupId: String, userId: String, rejectAddRequest: Boolean? = null) {
+    apiRequestUnit("set_group_kick", mapOf("group_id" to groupId, "user_id" to userId, "reject_add_request" to rejectAddRequest))
+}
+
+/**
+ * 退出群组
+ *
+ * 退出或解散指定群聊
+ * @param groupId 群号
+ * @param isDismiss 是否解散
+ */
+suspend fun NapCatBotApi.setGroupLeave(groupId: String, isDismiss: Boolean? = null) {
+    apiRequestUnit("set_group_leave", mapOf("group_id" to groupId, "is_dismiss" to isDismiss))
+}
+
+/**
+ * 设置群名称
+ *
+ * 修改指定群聊的名称
+ * @param groupId 群号
+ * @param groupName 群名称
+ */
+suspend fun NapCatBotApi.setGroupName(groupId: String, groupName: String) {
+    apiRequestUnit("set_group_name", mapOf("group_id" to groupId, "group_name" to groupName))
+}
+
+/**
+ * 全员禁言
+ *
+ * 开启或关闭指定群聊的全员禁言
+ * @param groupId 群号
+ * @param enable 是否开启全员禁言
+ */
+suspend fun NapCatBotApi.setGroupWholeBan(groupId: String, enable: Boolean? = null) {
+    apiRequestUnit("set_group_whole_ban", mapOf("group_id" to groupId, "enable" to enable))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatGroupExtraExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatGroupExtraExpand.kt
@@ -1,0 +1,140 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import tools.jackson.databind.JsonNode
+
+/**
+ * NapCatGroupExtraExpand
+ */
+class NapCatGroupExtraExpand {
+}
+
+/**
+ * 删除群相册媒体
+ * @param groupId 群号
+ * @param albumId 相册ID
+ * @param lloc 媒体ID (lloc)
+ */
+suspend fun NapCatBotApi.delGroupAlbumMedia(groupId: String, albumId: String, lloc: String) {
+    apiRequestUnit("del_group_album_media", mapOf("group_id" to groupId, "album_id" to albumId, "lloc" to lloc))
+}
+
+/**
+ * 发表群相册评论
+ * @param groupId 群号
+ * @param albumId 相册 ID
+ * @param lloc 图片 ID
+ * @param content 评论内容
+ */
+suspend fun NapCatBotApi.doGroupAlbumComment(groupId: String, albumId: String, lloc: String, content: String) {
+    apiRequestUnit("do_group_album_comment", mapOf("group_id" to groupId, "album_id" to albumId, "lloc" to lloc, "content" to content))
+}
+
+/**
+ * 获取群相册媒体列表
+ * @param groupId 群号
+ * @param albumId 相册ID
+ * @param attachInfo 附加信息（用于分页）
+ */
+suspend fun NapCatBotApi.getGroupAlbumMediaList(groupId: String, albumId: String, attachInfo: String): NapCatGroupExtraExpand.String {
+    return apiRequest("get_group_album_media_list", mapOf("group_id" to groupId, "album_id" to albumId, "attach_info" to attachInfo))
+}
+
+/**
+ * 获取群详细信息 (扩展)
+ * @param groupId 群号
+ */
+suspend fun NapCatBotApi.getGroupInfoEx(groupId: String): NapCatGroupExtraExpand.String {
+    return apiRequest("get_group_info_ex", mapOf("group_id" to groupId))
+}
+
+/**
+ * 获取群相册列表
+ * @param groupId 群号
+ */
+suspend fun NapCatBotApi.getQunAlbumList(groupId: String): NapCatGroupExtraExpand.List<String> {
+    return apiRequest("get_qun_album_list", mapOf("group_id" to groupId))
+}
+
+/**
+ * 群打卡
+ * @param groupId 群号
+ */
+suspend fun NapCatBotApi.sendGroupSign(groupId: String) {
+    apiRequestUnit("send_group_sign", mapOf("group_id" to groupId))
+}
+
+/**
+ * 设置群加群选项
+ * @param groupId 群号
+ * @param addType 加群方式
+ * @param groupQuestion 加群问题
+ * @param groupAnswer 加群答案
+ */
+suspend fun NapCatBotApi.setGroupAddOption(groupId: String, addType: Long, groupQuestion: String? = null, groupAnswer: String? = null) {
+    apiRequestUnit("set_group_add_option", mapOf("group_id" to groupId, "add_type" to addType, "group_question" to groupQuestion, "group_answer" to groupAnswer))
+}
+
+/**
+ * 点赞群相册媒体
+ * @param groupId 群号
+ * @param albumId 相册ID
+ * @param lloc 媒体ID (lloc)
+ * @param id 点赞ID
+ * @param set 是否点赞
+ */
+suspend fun NapCatBotApi.setGroupAlbumMediaLike(groupId: String, albumId: String, lloc: String, id: String, set: Boolean) {
+    apiRequestUnit("set_group_album_media_like", mapOf("group_id" to groupId, "album_id" to albumId, "lloc" to lloc, "id" to id, "set" to set))
+}
+
+/**
+ * 设置群备注
+ *
+ * 设置群备注
+ * @param groupId 群号
+ * @param remark 备注
+ */
+suspend fun NapCatBotApi.setGroupRemark(groupId: String, remark: String) {
+    apiRequestUnit("set_group_remark", mapOf("group_id" to groupId, "remark" to remark))
+}
+
+/**
+ * 设置群机器人加群选项
+ * @param groupId 群号
+ * @param robotMemberSwitch 机器人成员开关
+ * @param robotMemberExamine 机器人成员审核
+ */
+suspend fun NapCatBotApi.setGroupRobotAddOption(groupId: String, robotMemberSwitch: Long? = null, robotMemberExamine: Long? = null) {
+    apiRequestUnit("set_group_robot_add_option", mapOf("group_id" to groupId, "robot_member_switch" to robotMemberSwitch, "robot_member_examine" to robotMemberExamine))
+}
+
+/**
+ * 设置群搜索选项
+ * @param groupId 群号
+ * @param noCodeFingerOpen 未知
+ * @param noFingerOpen 未知
+ */
+suspend fun NapCatBotApi.setGroupSearch(groupId: String, noCodeFingerOpen: Long? = null, noFingerOpen: Long? = null) {
+    apiRequestUnit("set_group_search", mapOf("group_id" to groupId, "no_code_finger_open" to noCodeFingerOpen, "no_finger_open" to noFingerOpen))
+}
+
+/**
+ * 群打卡
+ * @param groupId 群号
+ */
+suspend fun NapCatBotApi.setGroupSign(groupId: String) {
+    apiRequestUnit("set_group_sign", mapOf("group_id" to groupId))
+}
+
+/**
+ * 上传图片到群相册
+ * @param groupId 群号
+ * @param albumId 相册ID
+ * @param albumName 相册名称
+ * @param file 图片路径、URL或Base64
+ */
+suspend fun NapCatBotApi.uploadImageToQunAlbum(groupId: String, albumId: String, albumName: String, file: String) {
+    apiRequestUnit("upload_image_to_qun_album", mapOf("group_id" to groupId, "album_id" to albumId, "album_name" to albumName, "file" to file))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatGuildApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatGuildApiExpand.kt
@@ -1,0 +1,30 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import tools.jackson.databind.JsonNode
+
+/**
+ * NapCatGuildApiExpand
+ */
+class NapCatGuildApiExpand {
+}
+
+/**
+ * 获取频道列表
+ *
+ * 获取当前帐号已加入的频道列表
+ */
+suspend fun NapCatBotApi.getGuildList(): JsonNode {
+    return apiRequest("get_guild_list")
+}
+
+/**
+ * 获取频道个人信息
+ *
+ * 获取当前帐号在频道中的个人资料
+ */
+suspend fun NapCatBotApi.getGuildServiceProfile(): JsonNode {
+    return apiRequest("get_guild_service_profile")
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatMessageApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatMessageApiExpand.kt
@@ -1,0 +1,197 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import tools.jackson.databind.JsonNode
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * NapCatMessageApiExpand
+ */
+class NapCatMessageApiExpand {
+    /**
+     * Msg
+     */
+    data class Msg(
+        /**
+         * 发送时间
+         */
+        @field:JsonProperty("time")
+        val time: Long,
+        /**
+         * 消息类型
+         */
+        @field:JsonProperty("message_type")
+        val messageType: String,
+        /**
+         * 消息ID
+         */
+        @field:JsonProperty("message_id")
+        val messageId: Long,
+        /**
+         * 真实ID
+         */
+        @field:JsonProperty("real_id")
+        val realId: Long,
+        /**
+         * 消息序号
+         */
+        @field:JsonProperty("message_seq")
+        val messageSeq: Long,
+        /**
+         * sender
+         */
+        @field:JsonProperty("sender")
+        val sender: String,
+        /**
+         * message
+         */
+        @field:JsonProperty("message")
+        val message: String,
+        /**
+         * 原始消息内容
+         */
+        @field:JsonProperty("raw_message")
+        val rawMessage: String,
+        /**
+         * 字体
+         */
+        @field:JsonProperty("font")
+        val font: Long,
+        /**
+         * 群号
+         */
+        @field:JsonProperty("group_id")
+        val groupId: Long?,
+        /**
+         * 发送者QQ号
+         */
+        @field:JsonProperty("user_id")
+        val userId: Long,
+        /**
+         * 表情回应列表
+         */
+        @field:JsonProperty("emoji_likes_list")
+        val emojiLikesList: List<String>?
+    )
+
+}
+
+/**
+ * 标记所有消息已读
+ */
+suspend fun NapCatBotApi.markAllAsRead() {
+    apiRequestUnit("_mark_all_as_read")
+}
+
+/**
+ * 撤回消息
+ *
+ * 撤回已发送的消息
+ * @param messageId 消息ID
+ */
+suspend fun NapCatBotApi.deleteMsg(messageId: Long) {
+    apiRequestUnit("delete_msg", mapOf("message_id" to messageId))
+}
+
+/**
+ * 转发单条消息
+ *
+ * 转发单条消息
+ * @param messageId 消息ID
+ * @param groupId 目标群号
+ * @param userId 目标用户QQ
+ */
+suspend fun NapCatBotApi.forwardFriendSingleMsg(messageId: Long, groupId: String? = null, userId: String? = null) {
+    apiRequestUnit("forward_friend_single_msg", mapOf("message_id" to messageId, "group_id" to groupId, "user_id" to userId))
+}
+
+/**
+ * 转发单条消息
+ *
+ * 转发单条消息
+ * @param messageId 消息ID
+ * @param groupId 目标群号
+ * @param userId 目标用户QQ
+ */
+suspend fun NapCatBotApi.forwardGroupSingleMsg(messageId: Long, groupId: String? = null, userId: String? = null) {
+    apiRequestUnit("forward_group_single_msg", mapOf("message_id" to messageId, "group_id" to groupId, "user_id" to userId))
+}
+
+/**
+ * 获取消息
+ *
+ * 根据消息 ID 获取消息详细信息
+ * @param messageId 消息ID
+ */
+suspend fun NapCatBotApi.getMsg(messageId: Long): NapCatMessageApiExpand.Msg {
+    return apiRequest("get_msg", mapOf("message_id" to messageId))
+}
+
+/**
+ * 标记群聊已读
+ *
+ * 标记指定渠道的消息为已读
+ * @param userId 用户QQ
+ * @param groupId 群号
+ * @param messageId 消息ID
+ */
+suspend fun NapCatBotApi.markGroupMsgAsRead(userId: String? = null, groupId: String? = null, messageId: String? = null) {
+    apiRequestUnit("mark_group_msg_as_read", mapOf("user_id" to userId, "group_id" to groupId, "message_id" to messageId))
+}
+
+/**
+ * 标记消息已读 (Go-CQHTTP)
+ *
+ * 标记指定渠道的消息为已读
+ * @param userId 用户QQ
+ * @param groupId 群号
+ * @param messageId 消息ID
+ */
+suspend fun NapCatBotApi.markMsgAsRead(userId: String? = null, groupId: String? = null, messageId: String? = null) {
+    apiRequestUnit("mark_msg_as_read", mapOf("user_id" to userId, "group_id" to groupId, "message_id" to messageId))
+}
+
+/**
+ * 标记私聊已读
+ *
+ * 标记指定渠道的消息为已读
+ * @param userId 用户QQ
+ * @param groupId 群号
+ * @param messageId 消息ID
+ */
+suspend fun NapCatBotApi.markPrivateMsgAsRead(userId: String? = null, groupId: String? = null, messageId: String? = null) {
+    apiRequestUnit("mark_private_msg_as_read", mapOf("user_id" to userId, "group_id" to groupId, "message_id" to messageId))
+}
+
+/**
+ * 发送消息
+ *
+ * 发送私聊或群聊消息
+ * @param messageType 消息类型 (private/group)
+ * @param userId 用户QQ
+ * @param groupId 群号
+ * @param message OneBot 11 消息混合类型
+ * @param autoEscape 是否作为纯文本发送
+ * @param source 合并转发来源
+ * @param news 合并转发新闻
+ * @param summary 合并转发摘要
+ * @param prompt 合并转发提示
+ */
+suspend fun NapCatBotApi.sendMsg(messageType: String? = null, userId: String? = null, groupId: String? = null, message: List<MessageItem>, autoEscape: Boolean? = null, source: String? = null, news: List<NewsItem>? = null, summary: String? = null, prompt: String? = null) {
+    apiRequestUnit("send_msg", mapOf("message_type" to messageType, "user_id" to userId, "group_id" to groupId, "message" to message, "auto_escape" to autoEscape, "source" to source, "news" to news, "summary" to summary, "prompt" to prompt))
+}
+
+/**
+ * 设置在线状态
+ *
+ * 
+## 状态列表
+
+### 在线
+
+ */
+suspend fun NapCatBotApi.setOnlineStatus() {
+    apiRequestUnit("set_online_status")
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatMessageExtraExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatMessageExtraExpand.kt
@@ -1,0 +1,187 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import tools.jackson.databind.JsonNode
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * NapCatMessageExtraExpand
+ */
+class NapCatMessageExtraExpand {
+    /**
+     * FetchEmojiLikeEmojiLikesListItem
+     */
+    data class FetchEmojiLikeEmojiLikesListItem(
+        /**
+         * TinyID
+         */
+        @field:JsonProperty("tinyId")
+        val tinyId: String,
+        /**
+         * 昵称
+         */
+        @field:JsonProperty("nickName")
+        val nickName: String,
+        /**
+         * 头像URL
+         */
+        @field:JsonProperty("headUrl")
+        val headUrl: String
+    )
+
+    /**
+     * FetchEmojiLike
+     */
+    data class FetchEmojiLike(
+        /**
+         * 表情回应列表
+         */
+        @field:JsonProperty("emojiLikesList")
+        val emojiLikesList: List<FetchEmojiLikeEmojiLikesListItem>,
+        /**
+         * 分页Cookie
+         */
+        @field:JsonProperty("cookie")
+        val cookie: String,
+        /**
+         * 是否最后一页
+         */
+        @field:JsonProperty("isLastPage")
+        val isLastPage: Boolean,
+        /**
+         * 是否第一页
+         */
+        @field:JsonProperty("isFirstPage")
+        val isFirstPage: Boolean,
+        /**
+         * 结果状态码
+         */
+        @field:JsonProperty("result")
+        val result: Long,
+        /**
+         * 错 误信息
+         */
+        @field:JsonProperty("errMsg")
+        val errMsg: String
+    )
+
+    /**
+     * EmojiLikesEmojiLikeListItem
+     */
+    data class EmojiLikesEmojiLikeListItem(
+        /**
+         * 点击者QQ号
+         */
+        @field:JsonProperty("user_id")
+        val userId: String,
+        /**
+         * 昵称?
+         */
+        @field:JsonProperty("nick_name")
+        val nickName: String
+    )
+
+    /**
+     * EmojiLikes
+     */
+    data class EmojiLikes(
+        /**
+         * 表情回应列表
+         */
+        @field:JsonProperty("emoji_like_list")
+        val emojiLikeList: List<EmojiLikesEmojiLikeListItem>
+    )
+
+}
+
+/**
+ * 分享群 (Ark)
+ *
+ * 获取群分享的 Ark 内容
+ * @param groupId 群号
+ */
+suspend fun NapCatBotApi.ArkShareGroup(groupId: String) {
+    apiRequestUnit("ArkShareGroup", mapOf("group_id" to groupId))
+}
+
+/**
+ * 分享用户 (Ark)
+ *
+ * 获取用户推荐的 Ark 内容
+ * @param userId QQ号
+ * @param groupId 群号
+ * @param phoneNumber 手机号
+ */
+suspend fun NapCatBotApi.ArkSharePeer(userId: String? = null, groupId: String? = null, phoneNumber: String) {
+    apiRequestUnit("ArkSharePeer", mapOf("user_id" to userId, "group_id" to groupId, "phone_number" to phoneNumber))
+}
+
+/**
+ * 点击内联键盘按钮
+ * @param groupId 群号
+ * @param botAppid 机器人AppID
+ * @param buttonId 按钮ID
+ * @param callbackData 回调数据
+ * @param msgSeq 消息序列号
+ */
+suspend fun NapCatBotApi.clickInlineKeyboardButton(groupId: String, botAppid: String, buttonId: String, callbackData: String, msgSeq: String) {
+    apiRequestUnit("click_inline_keyboard_button", mapOf("group_id" to groupId, "bot_appid" to botAppid, "button_id" to buttonId, "callback_data" to callbackData, "msg_seq" to msgSeq))
+}
+
+/**
+ * 获取表情点赞详情
+ * @param messageId 消息ID
+ * @param emojiId 表情ID
+ * @param emojiType 表情类型
+ * @param count 获取数量
+ * @param cookie 分页Cookie
+ */
+suspend fun NapCatBotApi.fetchEmojiLike(messageId: Long, emojiId: Long, emojiType: Long, count: Long, cookie: String): NapCatMessageExtraExpand.FetchEmojiLike {
+    return apiRequest("fetch_emoji_like", mapOf("message_id" to messageId, "emojiId" to emojiId, "emojiType" to emojiType, "count" to count, "cookie" to cookie))
+}
+
+/**
+ * 获取消息表情点赞列表
+ * @param groupId 群号，短ID可不传
+ * @param messageId 消息ID，可以传递长ID或短ID
+ * @param emojiId 表情ID
+ * @param emojiType 表情类型
+ * @param count 数量，0代表全部
+ */
+suspend fun NapCatBotApi.getEmojiLikes(groupId: String? = null, messageId: String, emojiId: String, emojiType: String? = null, count: Long): NapCatMessageExtraExpand.EmojiLikes {
+    return apiRequest("get_emoji_likes", mapOf("group_id" to groupId, "message_id" to messageId, "emoji_id" to emojiId, "emoji_type" to emojiType, "count" to count))
+}
+
+/**
+ * 分享用户 (Ark)
+ *
+ * 获取用户推荐的 Ark 内容
+ * @param userId QQ号
+ * @param groupId 群号
+ * @param phoneNumber 手机号
+ */
+suspend fun NapCatBotApi.sendArkShare(userId: String? = null, groupId: String? = null, phoneNumber: String) {
+    apiRequestUnit("send_ark_share", mapOf("user_id" to userId, "group_id" to groupId, "phone_number" to phoneNumber))
+}
+
+/**
+ * 分享群 (Ark)
+ *
+ * 获取群分享的 Ark 内容
+ * @param groupId 群号
+ */
+suspend fun NapCatBotApi.sendGroupArkShare(groupId: String) {
+    apiRequestUnit("send_group_ark_share", mapOf("group_id" to groupId))
+}
+
+/**
+ * 设置消息表情点赞
+ * @param messageId 消息ID
+ * @param emojiId 表情ID
+ * @param set 是否设置
+ */
+suspend fun NapCatBotApi.setMsgEmojiLike(messageId: Long, emojiId: Long, set: Boolean? = null) {
+    apiRequestUnit("set_msg_emoji_like", mapOf("message_id" to messageId, "emoji_id" to emojiId, "set" to set))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatMessageGroupSendExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatMessageGroupSendExpand.kt
@@ -1,0 +1,23 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import tools.jackson.databind.JsonNode
+
+/**
+ * NapCatMessageGroupSendExpand
+ */
+class NapCatMessageGroupSendExpand {
+}
+
+/**
+ * 发送群艾特
+ *
+ * 发送群消息
+ * @param groupId group_id
+ * @param message message
+ */
+suspend fun NapCatBotApi.sendGroupMsg(groupId: Long, message: List<MessageItem>) {
+    apiRequestUnit("send_group_msg", mapOf("group_id" to groupId, "message" to message))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatMessagePrivateSendExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatMessagePrivateSendExpand.kt
@@ -1,0 +1,23 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import tools.jackson.databind.JsonNode
+
+/**
+ * NapCatMessagePrivateSendExpand
+ */
+class NapCatMessagePrivateSendExpand {
+}
+
+/**
+ * 发送私聊图片
+ *
+ * 发送群消息
+ * @param userId user_id
+ * @param message message
+ */
+suspend fun NapCatBotApi.sendPrivateMsg(userId: Long, message: List<JsonNode>) {
+    apiRequestUnit("send_private_msg", mapOf("user_id" to userId, "message" to message))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatNapCatOtherApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatNapCatOtherApiExpand.kt
@@ -1,0 +1,19 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import tools.jackson.databind.JsonNode
+
+/**
+ * NapCatNapCatOtherApiExpand
+ */
+class NapCatNapCatOtherApiExpand {
+}
+
+/**
+ * unknown
+ */
+suspend fun NapCatBotApi.unknown() {
+    apiRequestUnit("unknown")
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatStreamApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatStreamApiExpand.kt
@@ -1,0 +1,44 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import tools.jackson.databind.JsonNode
+
+/**
+ * NapCatStreamApiExpand
+ */
+class NapCatStreamApiExpand {
+}
+
+/**
+ * 下载文件流
+ *
+ * 以流式方式从网络或本地下载文件
+ * @param file 文件路径或 URL
+ * @param fileId 文件 ID
+ * @param chunkSize 分块大小 (字节)
+ */
+suspend fun NapCatBotApi.downloadFileStream(file: String? = null, fileId: String? = null, chunkSize: Long? = null): NapCatStreamApiExpand.String {
+    return apiRequest("download_file_stream", mapOf("file" to file, "file_id" to fileId, "chunk_size" to chunkSize))
+}
+
+/**
+ * 上传文件流
+ *
+ * 以流式方式上传文件数据到机器人
+ * @param streamId 流 ID
+ * @param chunkData 分块数据 (Base64)
+ * @param chunkIndex 分块索引
+ * @param totalChunks 总分块数
+ * @param fileSize 文件总大小
+ * @param expectedSha256 期望的 SHA256
+ * @param isComplete 是否完成
+ * @param filename 文件名
+ * @param reset 是否重置
+ * @param verifyOnly 是否仅验证
+ * @param fileRetention 文件保留时间 (毫秒)
+ */
+suspend fun NapCatBotApi.uploadFileStream(streamId: String, chunkData: String? = null, chunkIndex: Long? = null, totalChunks: Long? = null, fileSize: Long? = null, expectedSha256: String? = null, isComplete: Boolean? = null, filename: String? = null, reset: Boolean? = null, verifyOnly: Boolean? = null, fileRetention: Long) {
+    apiRequestUnit("upload_file_stream", mapOf("stream_id" to streamId, "chunk_data" to chunkData, "chunk_index" to chunkIndex, "total_chunks" to totalChunks, "file_size" to fileSize, "expected_sha256" to expectedSha256, "is_complete" to isComplete, "filename" to filename, "reset" to reset, "verify_only" to verifyOnly, "file_retention" to fileRetention))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatStreamTransferExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatStreamTransferExpand.kt
@@ -1,0 +1,48 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import tools.jackson.databind.JsonNode
+
+/**
+ * NapCatStreamTransferExpand
+ */
+class NapCatStreamTransferExpand {
+}
+
+/**
+ * 清理流式传输临时文件
+ */
+suspend fun NapCatBotApi.cleanStreamTempFile() {
+    apiRequestUnit("clean_stream_temp_file")
+}
+
+/**
+ * 下载图片文件流
+ * @param file 文件路径或 URL
+ * @param fileId 文件 ID
+ * @param chunkSize 分块大小 (字节)
+ */
+suspend fun NapCatBotApi.downloadFileImageStream(file: String? = null, fileId: String? = null, chunkSize: Long? = null): NapCatStreamTransferExpand.String {
+    return apiRequest("download_file_image_stream", mapOf("file" to file, "file_id" to fileId, "chunk_size" to chunkSize))
+}
+
+/**
+ * 下载语音文件流
+ * @param file 文件路径或 URL
+ * @param fileId 文件 ID
+ * @param chunkSize 分块大小 (字节)
+ * @param outFormat 输出格式
+ */
+suspend fun NapCatBotApi.downloadFileRecordStream(file: String? = null, fileId: String? = null, chunkSize: Long? = null, outFormat: String? = null): NapCatStreamTransferExpand.String {
+    return apiRequest("download_file_record_stream", mapOf("file" to file, "file_id" to fileId, "chunk_size" to chunkSize, "out_format" to outFormat))
+}
+
+/**
+ * 测试下载流
+ * @param error 是否触发测试错误
+ */
+suspend fun NapCatBotApi.testDownloadStream(error: Boolean? = null): NapCatStreamTransferExpand.String {
+    return apiRequest("test_download_stream", mapOf("error" to error))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatSystemApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatSystemApiExpand.kt
@@ -1,0 +1,464 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import tools.jackson.databind.JsonNode
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * NapCatSystemApiExpand
+ */
+class NapCatSystemApiExpand {
+    /**
+     * Credentials
+     */
+    data class Credentials(
+        /**
+         * Cookies
+         */
+        @field:JsonProperty("cookies")
+        val cookies: String,
+        /**
+         * CSRF Token
+         */
+        @field:JsonProperty("token")
+        val token: Long
+    )
+
+    /**
+     * CsrfToken
+     */
+    data class CsrfToken(
+        /**
+         * CSRF Token
+         */
+        @field:JsonProperty("token")
+        val token: Long
+    )
+
+    /**
+     * GroupSystemMsgInvitedRequestsItem
+     */
+    data class GroupSystemMsgInvitedRequestsItem(
+        /**
+         * 请求ID
+         */
+        @field:JsonProperty("request_id")
+        val requestId: Long,
+        /**
+         * 邀请者QQ
+         */
+        @field:JsonProperty("invitor_uin")
+        val invitorUin: Long,
+        /**
+         * 邀请者昵称
+         */
+        @field:JsonProperty("invitor_nick")
+        val invitorNick: String,
+        /**
+         * 群号
+         */
+        @field:JsonProperty("group_id")
+        val groupId: Long,
+        /**
+         * 群名称
+         */
+        @field:JsonProperty("group_name")
+        val groupName: String,
+        /**
+         * 附言
+         */
+        @field:JsonProperty("message")
+        val message: String,
+        /**
+         * 是否已处理
+         */
+        @field:JsonProperty("checked")
+        val checked: Boolean,
+        /**
+         * 操作者QQ
+         */
+        @field:JsonProperty("actor")
+        val actor: Long,
+        /**
+         * 申请者昵称
+         */
+        @field:JsonProperty("requester_nick")
+        val requesterNick: String
+    )
+
+    /**
+     * GroupSystemMsgInvitedRequestItem
+     */
+    data class GroupSystemMsgInvitedRequestItem(
+        /**
+         * 请求ID
+         */
+        @field:JsonProperty("request_id")
+        val requestId: Long,
+        /**
+         * 邀请者QQ
+         */
+        @field:JsonProperty("invitor_uin")
+        val invitorUin: Long,
+        /**
+         * 邀请者昵称
+         */
+        @field:JsonProperty("invitor_nick")
+        val invitorNick: String,
+        /**
+         * 群号
+         */
+        @field:JsonProperty("group_id")
+        val groupId: Long,
+        /**
+         * 群名称
+         */
+        @field:JsonProperty("group_name")
+        val groupName: String,
+        /**
+         * 附言
+         */
+        @field:JsonProperty("message")
+        val message: String,
+        /**
+         * 是否已处理
+         */
+        @field:JsonProperty("checked")
+        val checked: Boolean,
+        /**
+         * 操作者QQ
+         */
+        @field:JsonProperty("actor")
+        val actor: Long,
+        /**
+         * 申请者昵称
+         */
+        @field:JsonProperty("requester_nick")
+        val requesterNick: String
+    )
+
+    /**
+     * GroupSystemMsgJoinRequestsItem
+     */
+    data class GroupSystemMsgJoinRequestsItem(
+        /**
+         * 请求ID
+         */
+        @field:JsonProperty("request_id")
+        val requestId: Long,
+        /**
+         * 邀请者QQ
+         */
+        @field:JsonProperty("invitor_uin")
+        val invitorUin: Long,
+        /**
+         * 邀请者昵称
+         */
+        @field:JsonProperty("invitor_nick")
+        val invitorNick: String,
+        /**
+         * 群号
+         */
+        @field:JsonProperty("group_id")
+        val groupId: Long,
+        /**
+         * 群名称
+         */
+        @field:JsonProperty("group_name")
+        val groupName: String,
+        /**
+         * 附言
+         */
+        @field:JsonProperty("message")
+        val message: String,
+        /**
+         * 是否已处理
+         */
+        @field:JsonProperty("checked")
+        val checked: Boolean,
+        /**
+         * 操作者QQ
+         */
+        @field:JsonProperty("actor")
+        val actor: Long,
+        /**
+         * 申请者昵称
+         */
+        @field:JsonProperty("requester_nick")
+        val requesterNick: String
+    )
+
+    /**
+     * GroupSystemMsg
+     */
+    data class GroupSystemMsg(
+        /**
+         * 进群邀请列表
+         */
+        @field:JsonProperty("invited_requests")
+        val invitedRequests: List<GroupSystemMsgInvitedRequestsItem>,
+        /**
+         * 进群邀请列表 (兼容)
+         */
+        @field:JsonProperty("InvitedRequest")
+        val InvitedRequest: List<GroupSystemMsgInvitedRequestItem>,
+        /**
+         * 进群申请列表
+         */
+        @field:JsonProperty("join_requests")
+        val joinRequests: List<GroupSystemMsgJoinRequestsItem>
+    )
+
+    /**
+     * LoginInfo
+     */
+    data class LoginInfo(
+        /**
+         * 出生年份
+         */
+        @field:JsonProperty("birthday_year")
+        val birthdayYear: Long?,
+        /**
+         * 出生月份
+         */
+        @field:JsonProperty("birthday_month")
+        val birthdayMonth: Long?,
+        /**
+         * 出生日期
+         */
+        @field:JsonProperty("birthday_day")
+        val birthdayDay: Long?,
+        /**
+         * 手机号
+         */
+        @field:JsonProperty("phone_num")
+        val phoneNum: String?,
+        /**
+         * 邮箱
+         */
+        @field:JsonProperty("email")
+        val email: String?,
+        /**
+         * 分组ID
+         */
+        @field:JsonProperty("category_id")
+        val categoryId: Long?,
+        /**
+         * QQ号
+         */
+        @field:JsonProperty("user_id")
+        val userId: Long,
+        /**
+         * 昵称
+         */
+        @field:JsonProperty("nickname")
+        val nickname: String,
+        /**
+         * 备注
+         */
+        @field:JsonProperty("remark")
+        val remark: String?,
+        /**
+         * 性别
+         */
+        @field:JsonProperty("sex")
+        val sex: String?,
+        /**
+         * 等级
+         */
+        @field:JsonProperty("level")
+        val level: Long?,
+        /**
+         * 年龄
+         */
+        @field:JsonProperty("age")
+        val age: Long?,
+        /**
+         * QID
+         */
+        @field:JsonProperty("qid")
+        val qid: String?,
+        /**
+         * 登录天数
+         */
+        @field:JsonProperty("login_days")
+        val loginDays: Long?,
+        /**
+         * 分组名称
+         */
+        @field:JsonProperty("categoryName")
+        val categoryName: String?,
+        /**
+         * 分组ID
+         */
+        @field:JsonProperty("categoryId")
+        val categoryId: Long?
+    )
+
+    /**
+     * Status
+     */
+    data class Status(
+        /**
+         * 是否在线
+         */
+        @field:JsonProperty("online")
+        val online: Boolean,
+        /**
+         * 状态是否良好
+         */
+        @field:JsonProperty("good")
+        val good: Boolean,
+        /**
+         * stat
+         */
+        @field:JsonProperty("stat")
+        val stat: String
+    )
+
+    /**
+     * VersionInfo
+     */
+    data class VersionInfo(
+        /**
+         * 应用名称
+         */
+        @field:JsonProperty("app_name")
+        val appName: String,
+        /**
+         * 协议版本
+         */
+        @field:JsonProperty("protocol_version")
+        val protocolVersion: String,
+        /**
+         * 应用版本
+         */
+        @field:JsonProperty("app_version")
+        val appVersion: String
+    )
+
+}
+
+/**
+ * 是否可以发送图片
+ *
+ * 检查是否可以发送图片
+ */
+suspend fun NapCatBotApi.canSendImage() {
+    apiRequestUnit("can_send_image")
+}
+
+/**
+ * 是否可以发送语音
+ *
+ * 检查是否可以发送语音
+ */
+suspend fun NapCatBotApi.canSendRecord() {
+    apiRequestUnit("can_send_record")
+}
+
+/**
+ * 清理缓存
+ *
+ * 清理缓存
+ */
+suspend fun NapCatBotApi.cleanCache() {
+    apiRequestUnit("clean_cache")
+}
+
+/**
+ * 获取登录凭证
+ *
+ * 获取登录凭证
+ * @param domain 需要获取 cookies 的域名
+ */
+suspend fun NapCatBotApi.getCredentials(domain: String): NapCatSystemApiExpand.Credentials {
+    return apiRequest("get_credentials", mapOf("domain" to domain))
+}
+
+/**
+ * 获取 CSRF Token
+ *
+ * 获取 CSRF Token
+ */
+suspend fun NapCatBotApi.getCsrfToken(): NapCatSystemApiExpand.CsrfToken {
+    return apiRequest("get_csrf_token")
+}
+
+/**
+ * 获取可疑好友申请
+ *
+ * 获取系统的可疑好友申请列表
+ * @param count 获取数量
+ */
+suspend fun NapCatBotApi.getDoubtFriendsAddRequest(count: Long): NapCatSystemApiExpand.String {
+    return apiRequest("get_doubt_friends_add_request", mapOf("count" to count))
+}
+
+/**
+ * 获取群系统消息
+ *
+ * 获取群系统消息
+ * @param count 获取的消息数量
+ */
+suspend fun NapCatBotApi.getGroupSystemMsg(count: Long): NapCatSystemApiExpand.GroupSystemMsg {
+    return apiRequest("get_group_system_msg", mapOf("count" to count))
+}
+
+/**
+ * 获取登录号信息
+ *
+ * 获取当前登录帐号的信息
+ */
+suspend fun NapCatBotApi.getLoginInfo(): NapCatSystemApiExpand.LoginInfo {
+    return apiRequest("get_login_info")
+}
+
+/**
+ * 获取运行状态
+ *
+ * 获取运行状态
+ */
+suspend fun NapCatBotApi.getStatus(): NapCatSystemApiExpand.Status {
+    return apiRequest("get_status")
+}
+
+/**
+ * 获取版本信息
+ *
+ * 获取版本信息
+ */
+suspend fun NapCatBotApi.getVersionInfo(): NapCatSystemApiExpand.VersionInfo {
+    return apiRequest("get_version_info")
+}
+
+/**
+ * 获取Packet状态
+ *
+ * 获取底层Packet服务的运行状态
+ */
+suspend fun NapCatBotApi.ncGetPacketStatus(): JsonNode {
+    return apiRequest("nc_get_packet_status")
+}
+
+/**
+ * 处理可疑好友申请
+ *
+ * 同意或拒绝系统的可疑好友申请
+ * @param flag 请求 flag
+ * @param approve 是否同意 (强制为 true)
+ */
+suspend fun NapCatBotApi.setDoubtFriendsAddRequest(flag: String, approve: Boolean) {
+    apiRequestUnit("set_doubt_friends_add_request", mapOf("flag" to flag, "approve" to approve))
+}
+
+/**
+ * 重启服务
+ *
+ * 重启服务
+ */
+suspend fun NapCatBotApi.setRestart() {
+    apiRequestUnit("set_restart")
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatSystemExtraExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatSystemExtraExpand.kt
@@ -1,0 +1,178 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import tools.jackson.databind.JsonNode
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * NapCatSystemExtraExpand
+ */
+class NapCatSystemExtraExpand {
+    /**
+     * MiniAppArk
+     */
+    data class MiniAppArk(
+        /**
+         * data
+         */
+        @field:JsonProperty("data")
+        val data: String
+    )
+
+    /**
+     * RkeyItemItem
+     */
+    data class RkeyItemItem(
+        /**
+         * 类型 (private/group)
+         */
+        @field:JsonProperty("type")
+        val type: String,
+        /**
+         * RKey
+         */
+        @field:JsonProperty("rkey")
+        val rkey: String,
+        /**
+         * 创建时间
+         */
+        @field:JsonProperty("created_at")
+        val createdAt: Long,
+        /**
+         * 有效期
+         */
+        @field:JsonProperty("ttl")
+        val ttl: Long
+    )
+
+    /**
+     * RkeyServer
+     */
+    data class RkeyServer(
+        /**
+         * 私聊 RKey
+         */
+        @field:JsonProperty("private_rkey")
+        val privateRkey: String?,
+        /**
+         * 群聊 RKey
+         */
+        @field:JsonProperty("group_rkey")
+        val groupRkey: String?,
+        /**
+         * 过期时间
+         */
+        @field:JsonProperty("expired_time")
+        val expiredTime: Long?,
+        /**
+         * 名称
+         */
+        @field:JsonProperty("name")
+        val name: String
+    )
+
+    /**
+     * NcGetUserStatus
+     */
+    data class NcGetUserStatus(
+        /**
+         * 在线状态
+         */
+        @field:JsonProperty("status")
+        val status: Long,
+        /**
+         * 扩展状态
+         */
+        @field:JsonProperty("ext_status")
+        val extStatus: Long
+    )
+
+}
+
+/**
+ * 退出登录
+ */
+suspend fun NapCatBotApi.botExit() {
+    apiRequestUnit("bot_exit")
+}
+
+/**
+ * 获取自定义表情
+ * @param count 获取数量
+ */
+suspend fun NapCatBotApi.fetchCustomFace(count: Long): NapCatSystemExtraExpand.List<String> {
+    return apiRequest("fetch_custom_face", mapOf("count" to count))
+}
+
+/**
+ * 获取收藏列表
+ * @param category 分类ID
+ * @param count 获取数量
+ */
+suspend fun NapCatBotApi.getCollectionList(category: String, count: String): NapCatSystemExtraExpand.String {
+    return apiRequest("get_collection_list", mapOf("category" to category, "count" to count))
+}
+
+/**
+ * 获取小程序 Ark
+ */
+suspend fun NapCatBotApi.getMiniAppArk(): NapCatSystemExtraExpand.MiniAppArk {
+    return apiRequest("get_mini_app_ark")
+}
+
+/**
+ * 获取扩展 RKey
+ */
+suspend fun NapCatBotApi.getRkey(): NapCatSystemExtraExpand.List<RkeyItemItem> {
+    return apiRequest("get_rkey")
+}
+
+/**
+ * 获取 RKey 服务器
+ */
+suspend fun NapCatBotApi.getRkeyServer(): NapCatSystemExtraExpand.RkeyServer {
+    return apiRequest("get_rkey_server")
+}
+
+/**
+ * 获取机器人 UIN 范围
+ */
+suspend fun NapCatBotApi.getRobotUinRange(): NapCatSystemExtraExpand.List<String> {
+    return apiRequest("get_robot_uin_range")
+}
+
+/**
+ * 获取 RKey
+ */
+suspend fun NapCatBotApi.ncGetRkey(): NapCatSystemExtraExpand.List<String> {
+    return apiRequest("nc_get_rkey")
+}
+
+/**
+ * 获取用户在线状态
+ * @param userId QQ号
+ */
+suspend fun NapCatBotApi.ncGetUserStatus(userId: String): NapCatSystemExtraExpand.NcGetUserStatus {
+    return apiRequest("nc_get_user_status", mapOf("user_id" to userId))
+}
+
+/**
+ * 发送原始数据包
+ * @param cmd 命令字
+ * @param data 十六进制数据
+ * @param rsp 是否等待响应
+ */
+suspend fun NapCatBotApi.sendPacket(cmd: String, data: String, rsp: String) {
+    apiRequestUnit("send_packet", mapOf("cmd" to cmd, "data" to data, "rsp" to rsp))
+}
+
+/**
+ * 设置输入状态
+ * @param userId QQ号
+ * @param eventType 事件类型
+ */
+suspend fun NapCatBotApi.setInputStatus(userId: String, eventType: Long) {
+    apiRequestUnit("set_input_status", mapOf("user_id" to userId, "event_type" to eventType))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatUserApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatUserApiExpand.kt
@@ -1,0 +1,230 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import tools.jackson.databind.JsonNode
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * NapCatUserApiExpand
+ */
+class NapCatUserApiExpand {
+    /**
+     * Cookies
+     */
+    data class Cookies(
+        /**
+         * Cookies
+         */
+        @field:JsonProperty("cookies")
+        val cookies: String,
+        /**
+         * CSRF Token
+         */
+        @field:JsonProperty("bkn")
+        val bkn: String
+    )
+
+    /**
+     * FriendItem
+     */
+    data class FriendItem(
+        /**
+         * 出生年份
+         */
+        @field:JsonProperty("birthday_year")
+        val birthdayYear: Long?,
+        /**
+         * 出生月份
+         */
+        @field:JsonProperty("birthday_month")
+        val birthdayMonth: Long?,
+        /**
+         * 出生日期
+         */
+        @field:JsonProperty("birthday_day")
+        val birthdayDay: Long?,
+        /**
+         * 手机号
+         */
+        @field:JsonProperty("phone_num")
+        val phoneNum: String?,
+        /**
+         * 邮箱
+         */
+        @field:JsonProperty("email")
+        val email: String?,
+        /**
+         * 分组ID
+         */
+        @field:JsonProperty("category_id")
+        val categoryId: Long?,
+        /**
+         * QQ号
+         */
+        @field:JsonProperty("user_id")
+        val userId: Long,
+        /**
+         * 昵称
+         */
+        @field:JsonProperty("nickname")
+        val nickname: String,
+        /**
+         * 备注
+         */
+        @field:JsonProperty("remark")
+        val remark: String?,
+        /**
+         * 性别
+         */
+        @field:JsonProperty("sex")
+        val sex: String?,
+        /**
+         * 等级
+         */
+        @field:JsonProperty("level")
+        val level: Long?,
+        /**
+         * 年龄
+         */
+        @field:JsonProperty("age")
+        val age: Long?,
+        /**
+         * QID
+         */
+        @field:JsonProperty("qid")
+        val qid: String?,
+        /**
+         * 登录天数
+         */
+        @field:JsonProperty("login_days")
+        val loginDays: Long?,
+        /**
+         * 分组名称
+         */
+        @field:JsonProperty("categoryName")
+        val categoryName: String?,
+        /**
+         * 分组ID
+         */
+        @field:JsonProperty("categoryId")
+        val categoryId: Long?
+    )
+
+    /**
+     * RecentContactItemItem
+     */
+    data class RecentContactItemItem(
+        /**
+         * lastestMsg
+         */
+        @field:JsonProperty("lastestMsg")
+        val lastestMsg: String,
+        /**
+         * 对象QQ
+         */
+        @field:JsonProperty("peerUin")
+        val peerUin: String,
+        /**
+         * 备注
+         */
+        @field:JsonProperty("remark")
+        val remark: String,
+        /**
+         * 消息时间
+         */
+        @field:JsonProperty("msgTime")
+        val msgTime: String,
+        /**
+         * 聊天类型
+         */
+        @field:JsonProperty("chatType")
+        val chatType: Long,
+        /**
+         * 消息ID
+         */
+        @field:JsonProperty("msgId")
+        val msgId: String,
+        /**
+         * 发送者昵称
+         */
+        @field:JsonProperty("sendNickName")
+        val sendNickName: String,
+        /**
+         * 发送者群名片
+         */
+        @field:JsonProperty("sendMemberName")
+        val sendMemberName: String,
+        /**
+         * 对象名称
+         */
+        @field:JsonProperty("peerName")
+        val peerName: String
+    )
+
+}
+
+/**
+ * 获取 Cookies
+ *
+ * 获取指定域名的 Cookies
+ * @param domain 需要获取 cookies 的域名
+ */
+suspend fun NapCatBotApi.getCookies(domain: String): NapCatUserApiExpand.Cookies {
+    return apiRequest("get_cookies", mapOf("domain" to domain))
+}
+
+/**
+ * 获取好友列表
+ *
+ * 获取当前帐号的好友列表
+ * @param noCache 是否不使用缓存
+ */
+suspend fun NapCatBotApi.getFriendList(noCache: Boolean? = null): NapCatUserApiExpand.List<FriendItem> {
+    return apiRequest("get_friend_list", mapOf("no_cache" to noCache))
+}
+
+/**
+ * 获取最近会话
+ *
+ * 获取最近会话
+ * @param count 获取的数量
+ */
+suspend fun NapCatBotApi.getRecentContact(count: Long): NapCatUserApiExpand.List<RecentContactItemItem> {
+    return apiRequest("get_recent_contact", mapOf("count" to count))
+}
+
+/**
+ * 点赞
+ *
+ * 给指定用户点赞
+ * @param userId 对方 QQ 号
+ * @param times 点赞次数
+ */
+suspend fun NapCatBotApi.sendLike(userId: String, times: Long) {
+    apiRequestUnit("send_like", mapOf("user_id" to userId, "times" to times))
+}
+
+/**
+ * 处理加好友请求
+ *
+ * 同意或拒绝加好友请求
+ * @param flag 加好友请求的 flag (需从上报中获取)
+ * @param approve 是否同意请求
+ * @param remark 添加后的好友备注
+ */
+suspend fun NapCatBotApi.setFriendAddRequest(flag: String, approve: String? = null, remark: String? = null) {
+    apiRequestUnit("set_friend_add_request", mapOf("flag" to flag, "approve" to approve, "remark" to remark))
+}
+
+/**
+ * 设置好友备注
+ *
+ * 设置好友备注
+ * @param userId 对方 QQ 号
+ * @param remark 备注内容
+ */
+suspend fun NapCatBotApi.setFriendRemark(userId: String, remark: String) {
+    apiRequestUnit("set_friend_remark", mapOf("user_id" to userId, "remark" to remark))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatUserExtraExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatUserExtraExpand.kt
@@ -1,0 +1,275 @@
+@file:Suppress("UNUSED", "UnusedReceiverParameter")
+
+package com.blr19c.falowp.bot.adapter.nc.expand
+
+import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
+import tools.jackson.databind.JsonNode
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * NapCatUserExtraExpand
+ */
+class NapCatUserExtraExpand {
+    /**
+     * FriendsWithCategoryItemItemBuddyListItem
+     */
+    data class FriendsWithCategoryItemItemBuddyListItem(
+        /**
+         * 出生年份
+         */
+        @field:JsonProperty("birthday_year")
+        val birthdayYear: Long?,
+        /**
+         * 出生月份
+         */
+        @field:JsonProperty("birthday_month")
+        val birthdayMonth: Long?,
+        /**
+         * 出生日期
+         */
+        @field:JsonProperty("birthday_day")
+        val birthdayDay: Long?,
+        /**
+         * 手机号
+         */
+        @field:JsonProperty("phone_num")
+        val phoneNum: String?,
+        /**
+         * 邮箱
+         */
+        @field:JsonProperty("email")
+        val email: String?,
+        /**
+         * 分组ID
+         */
+        @field:JsonProperty("category_id")
+        val categoryId: Long?,
+        /**
+         * QQ号
+         */
+        @field:JsonProperty("user_id")
+        val userId: Long,
+        /**
+         * 昵称
+         */
+        @field:JsonProperty("nickname")
+        val nickname: String,
+        /**
+         * 备注
+         */
+        @field:JsonProperty("remark")
+        val remark: String?,
+        /**
+         * 性别
+         */
+        @field:JsonProperty("sex")
+        val sex: String?,
+        /**
+         * 等级
+         */
+        @field:JsonProperty("level")
+        val level: Long?,
+        /**
+         * 年龄
+         */
+        @field:JsonProperty("age")
+        val age: Long?,
+        /**
+         * QID
+         */
+        @field:JsonProperty("qid")
+        val qid: String?,
+        /**
+         * 登录天数
+         */
+        @field:JsonProperty("login_days")
+        val loginDays: Long?,
+        /**
+         * 分组名称
+         */
+        @field:JsonProperty("categoryName")
+        val categoryName: String?,
+        /**
+         * 分组ID
+         */
+        @field:JsonProperty("categoryId")
+        val categoryId: Long?
+    )
+
+    /**
+     * FriendsWithCategoryItemItem
+     */
+    data class FriendsWithCategoryItemItem(
+        /**
+         * 分组ID
+         */
+        @field:JsonProperty("categoryId")
+        val categoryId: Long,
+        /**
+         * 分组名称
+         */
+        @field:JsonProperty("categoryName")
+        val categoryName: String,
+        /**
+         * 分组内好友数量
+         */
+        @field:JsonProperty("categoryMbCount")
+        val categoryMbCount: Long,
+        /**
+         * 好友列表
+         */
+        @field:JsonProperty("buddyList")
+        val buddyList: List<FriendsWithCategoryItemItemBuddyListItem>
+    )
+
+    /**
+     * ProfileLikeFavoriteInfo
+     */
+    data class ProfileLikeFavoriteInfo(
+        /**
+         * 点赞用户信息
+         */
+        @field:JsonProperty("userInfos")
+        val userInfos: List<String>,
+        /**
+         * 总点赞数
+         */
+        @field:JsonProperty("total_count")
+        val totalCount: Long,
+        /**
+         * 最后点赞时间
+         */
+        @field:JsonProperty("last_time")
+        val lastTime: Long,
+        /**
+         * 今日点赞数
+         */
+        @field:JsonProperty("today_count")
+        val todayCount: Long
+    )
+
+    /**
+     * ProfileLikeVoteInfo
+     */
+    data class ProfileLikeVoteInfo(
+        /**
+         * 总点赞数
+         */
+        @field:JsonProperty("total_count")
+        val totalCount: Long,
+        /**
+         * 新增点赞数
+         */
+        @field:JsonProperty("new_count")
+        val newCount: Long,
+        /**
+         * 新增附近点赞数
+         */
+        @field:JsonProperty("new_nearby_count")
+        val newNearbyCount: Long,
+        /**
+         * 最后访问时间
+         */
+        @field:JsonProperty("last_visit_time")
+        val lastVisitTime: Long,
+        /**
+         * 点赞用户信息
+         */
+        @field:JsonProperty("userInfos")
+        val userInfos: List<String>
+    )
+
+    /**
+     * ProfileLike
+     */
+    data class ProfileLike(
+        /**
+         * 用户UID
+         */
+        @field:JsonProperty("uid")
+        val uid: String,
+        /**
+         * 时间
+         */
+        @field:JsonProperty("time")
+        val time: String,
+        /**
+         * favoriteInfo
+         */
+        @field:JsonProperty("favoriteInfo")
+        val favoriteInfo: ProfileLikeFavoriteInfo,
+        /**
+         * voteInfo
+         */
+        @field:JsonProperty("voteInfo")
+        val voteInfo: ProfileLikeVoteInfo
+    )
+
+    /**
+     * UnidirectionalFriendItem
+     */
+    data class UnidirectionalFriendItem(
+        /**
+         * QQ号
+         */
+        @field:JsonProperty("uin")
+        val uin: Long,
+        /**
+         * 用户UID
+         */
+        @field:JsonProperty("uid")
+        val uid: String,
+        /**
+         * 昵称
+         */
+        @field:JsonProperty("nick_name")
+        val nickName: String,
+        /**
+         * 年龄
+         */
+        @field:JsonProperty("age")
+        val age: Long,
+        /**
+         * 来源
+         */
+        @field:JsonProperty("source")
+        val source: String
+    )
+
+}
+
+/**
+ * 获取带分组的好友列表
+ */
+suspend fun NapCatBotApi.getFriendsWithCategory(): NapCatUserExtraExpand.List<FriendsWithCategoryItemItem> {
+    return apiRequest("get_friends_with_category")
+}
+
+/**
+ * 获取资料点赞
+ * @param userId QQ号
+ * @param start 起始位置
+ * @param count 获取数量
+ */
+suspend fun NapCatBotApi.getProfileLike(userId: String? = null, start: Long, count: Long): NapCatUserExtraExpand.ProfileLike {
+    return apiRequest("get_profile_like", mapOf("user_id" to userId, "start" to start, "count" to count))
+}
+
+/**
+ * 获取单向好友列表
+ */
+suspend fun NapCatBotApi.getUnidirectionalFriendList(): NapCatUserExtraExpand.List<UnidirectionalFriendItem> {
+    return apiRequest("get_unidirectional_friend_list")
+}
+
+/**
+ * 设置自定义在线状态
+ *
+ * 设置自定义在线状态
+ * @param faceId 图标ID
+ * @param faceType 图标类型
+ * @param wording 状态文字内容
+ */
+suspend fun NapCatBotApi.setDiyOnlineStatus(faceId: Long, faceType: Long, wording: String) {
+    apiRequestUnit("set_diy_online_status", mapOf("face_id" to faceId, "face_type" to faceType, "wording" to wording))
+}

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/bak/NapCatAccountExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/bak/NapCatAccountExpand.kt
@@ -1,4 +1,4 @@
-package com.blr19c.falowp.bot.adapter.nc.expand
+package com.blr19c.falowp.bot.adapter.nc.expand.bak
 
 import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
 import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApiSupport

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/bak/NapCatFileExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/bak/NapCatFileExpand.kt
@@ -1,4 +1,4 @@
-package com.blr19c.falowp.bot.adapter.nc.expand
+package com.blr19c.falowp.bot.adapter.nc.expand.bak
 
 import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
 import com.blr19c.falowp.bot.system.json.Json

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/bak/NapCatGroupExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/bak/NapCatGroupExpand.kt
@@ -1,4 +1,4 @@
-package com.blr19c.falowp.bot.adapter.nc.expand
+package com.blr19c.falowp.bot.adapter.nc.expand.bak
 
 import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
 import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApiSupport

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/bak/NapCatMessageExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/bak/NapCatMessageExpand.kt
@@ -1,4 +1,4 @@
-package com.blr19c.falowp.bot.adapter.nc.expand
+package com.blr19c.falowp.bot.adapter.nc.expand.bak
 
 import com.blr19c.falowp.bot.adapter.nc.api.NapCatBotApi
 import com.blr19c.falowp.bot.adapter.nc.message.NapCatMessage


### PR DESCRIPTION
### Motivation
- Align NapCat expansion sources with the official API docs and ensure every request parameter has a KDoc `@param` entry for improved documentation and IDE hints. 
- Regenerate expansion classes so models remain nested inside their owning expansion class and request/response shapes follow documented schemas.

### Description
- Regenerated expansion sources under `com.blr19c.falowp.bot.adapter.nc.expand` (20 classes covering 162 endpoints) and added `@param` KDoc entries for all request parameters. 
- Kept nested `data class` model definitions with `@field:JsonProperty` annotations and descriptive field KDoc, and moved legacy expand implementations into `expand.bak`. 
- Added/updated many `suspend fun NapCatBotApi.*` extension functions to include documented parameter names and descriptions in their KDoc. 
- Minor tidy in `NapCatExpandApi.kt` around `apiRequest` helpers (no behavioral changes to request helpers).

### Testing
- Ran `python` generator that fetched Apifox docs and reported `generated classes 20` and `generated endpoints 162`, indicating successful generation. (succeeded)
- Installed Python dependencies with `pip install requests pyyaml` to support the generator. (succeeded)
- No Kotlin/Gradle compile or unit tests were executed in this change set. (not run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979d75b39b483288f68bc7bc4afe357)