### PR TITLE
Add @param docs to NapCat NC expand APIs and require explicit group/user IDs

### DIFF
--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatAiExtraExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatAiExtraExpand.kt
@@ -14,6 +14,10 @@ class NapCatAiExtraExpand {
  * 获取 AI 语音
  *
  * 通过 AI 语音引擎获取指定文本的语音 URL
+ *
+ * @param character AI 角色标识
+ * @param groupId 群组ID
+ * @param text 文本内容
  */
 suspend fun NapCatBotApi.getAiRecord(character: String, groupId: String, text: String): String {
     return apiRequest("get_ai_record", mapOf("character" to character, "group_id" to groupId, "text" to text))
@@ -23,6 +27,10 @@ suspend fun NapCatBotApi.getAiRecord(character: String, groupId: String, text: S
  * 发送群 AI 语音
  *
  * 发送 AI 生成的语音到指定群聊
+ *
+ * @param character AI 角色标识
+ * @param groupId 群组ID
+ * @param text 文本内容
  */
 suspend fun NapCatBotApi.sendGroupAiRecord(character: String, groupId: String, text: String) {
     apiRequestUnit("send_group_ai_record", mapOf("character" to character, "group_id" to groupId, "text" to text))

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatExpandApi.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatExpandApi.kt
@@ -78,6 +78,12 @@ data class NapCatWsEcho(
     val echo: String,
 )
 
+/**
+ * 发起 API 请求并返回原始结果
+ *
+ * @param type 请求类型
+ * @param body 请求体
+ */
 private suspend inline fun <reified T : Any> NapCatBotApi.apiRequestResult(
     type: String,
     body: Any? = null
@@ -93,12 +99,24 @@ private suspend inline fun <reified T : Any> NapCatBotApi.apiRequestResult(
     }
 }
 
+/**
+ * 发起 API 请求并返回数据
+ *
+ * @param type 请求类型
+ * @param body 请求体
+ */
 internal suspend inline fun <reified T : Any> NapCatBotApi.apiRequest(type: String, body: Any? = null): T {
     val result = apiRequestResult<T>(type, body)
     if (result.success()) return result.data ?: throw IllegalStateException("NapCat-API-请求失败-无返回结果")
     throw IllegalStateException("NapCat-API-请求失败:${result.msg ?: ""}${result.wording ?: ""}")
 }
 
+/**
+ * 发起 API 请求并忽略返回值
+ *
+ * @param type 请求类型
+ * @param body 请求体
+ */
 internal suspend fun NapCatBotApi.apiRequestUnit(type: String, body: Any? = null) {
     val result = apiRequestResult<Unit>(type, body)
     if (result.success()) return

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatExtraApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatExtraApiExpand.kt
@@ -61,6 +61,9 @@ class NapCatExtraApiExpand {
 
 /**
  * 创建收藏
+ *
+ * @param rawData 原始数据
+ * @param brief 简要描述
  */
 suspend fun NapCatBotApi.createCollection(rawData: String, brief: String) {
     apiRequestUnit("create_collection", mapOf("rawData" to rawData, "brief" to brief))
@@ -70,6 +73,9 @@ suspend fun NapCatBotApi.createCollection(rawData: String, brief: String) {
  * 获取AI角色列表
  *
  * 获取群聊中的AI角色列表
+ *
+ * @param groupId 群组ID
+ * @param chatType 聊天类型
  */
 suspend fun NapCatBotApi.getAiCharacters(
     groupId: String,
@@ -91,6 +97,8 @@ suspend fun NapCatBotApi.getClientKey(): NapCatExtraApiExpand.ClientKey {
  * 图片 OCR 识别
  *
  * 识别图片中的文字内容(仅Windows端支持)
+ *
+ * @param image 图片数据
  */
 suspend fun NapCatBotApi.ocrImage(image: String) {
     apiRequestUnit("ocr_image", mapOf("image" to image))
@@ -100,6 +108,10 @@ suspend fun NapCatBotApi.ocrImage(image: String) {
  * 批量踢出群成员
  *
  * 从指定群聊中批量踢出多个成员
+ *
+ * @param groupId 群组ID
+ * @param userId 用户ID列表
+ * @param rejectAddRequest 是否拒绝再次申请
  */
 suspend fun NapCatBotApi.setGroupKickMembers(groupId: String, userId: List<String>, rejectAddRequest: Boolean? = null) {
     apiRequestUnit(
@@ -112,6 +124,10 @@ suspend fun NapCatBotApi.setGroupKickMembers(groupId: String, userId: List<Strin
  * 设置专属头衔
  *
  * 设置群聊中指定成员的专属头衔
+ *
+ * @param groupId 群组ID
+ * @param userId 用户ID
+ * @param specialTitle 专属头衔
  */
 suspend fun NapCatBotApi.setGroupSpecialTitle(groupId: String, userId: String, specialTitle: String) {
     apiRequestUnit(
@@ -124,6 +140,8 @@ suspend fun NapCatBotApi.setGroupSpecialTitle(groupId: String, userId: String, s
  * 设置QQ头像
  *
  * 修改当前账号的QQ头像
+ *
+ * @param file 头像文件
  */
 suspend fun NapCatBotApi.setQqAvatar(file: String) {
     apiRequestUnit("set_qq_avatar", mapOf("file" to file))
@@ -133,6 +151,8 @@ suspend fun NapCatBotApi.setQqAvatar(file: String) {
  * 设置个性签名
  *
  * 修改当前登录帐号的个性签名
+ *
+ * @param longNick 个性签名内容
  */
 suspend fun NapCatBotApi.setSelfLongnick(longNick: String) {
     apiRequestUnit("set_self_longnick", mapOf("longNick" to longNick))
@@ -142,6 +162,8 @@ suspend fun NapCatBotApi.setSelfLongnick(longNick: String) {
  * 英文单词翻译
  *
  * 将英文单词列表翻译为中文
+ *
+ * @param words 英文单词列表
  */
 suspend fun NapCatBotApi.translateEn2zh(words: List<String>) {
     apiRequestUnit("translate_en2zh", mapOf("words" to words))

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatFileApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatFileApiExpand.kt
@@ -140,6 +140,9 @@ class NapCatFileApiExpand {
  * 获取文件
  *
  * 获取指定文件的详细信息及下载路径
+ *
+ * @param file 文件路径
+ * @param fileId 文件ID
  */
 suspend fun NapCatBotApi.getFile(file: String? = null, fileId: String? = null): NapCatFileApiExpand.File {
     return apiRequest("get_file", mapOf("file" to file, "file_id" to fileId))
@@ -149,9 +152,13 @@ suspend fun NapCatBotApi.getFile(file: String? = null, fileId: String? = null): 
  * 获取群文件URL
  *
  * 获取指定群文件的下载链接
+ *
+ * @param groupId 群组ID
+ * @param fileId 文件ID
+ * @param busid 业务ID
  */
 suspend fun NapCatBotApi.getGroupFileUrl(
-    groupId: String = this.receiveMessage.source.id,
+    groupId: String,
     fileId: String,
     busid: Int? = null
 ): NapCatFileApiExpand.GroupFileUrl {
@@ -169,6 +176,9 @@ suspend fun NapCatBotApi.getGroupFileUrl(
  * 获取图片
  *
  * 获取指定图片的信息及路径
+ *
+ * @param file 文件路径
+ * @param fileId 文件ID
  */
 suspend fun NapCatBotApi.getImage(file: String? = null, fileId: String? = null): NapCatFileApiExpand.Image {
     return apiRequest("get_image", mapOf("file" to file, "file_id" to fileId))
@@ -178,6 +188,8 @@ suspend fun NapCatBotApi.getImage(file: String? = null, fileId: String? = null):
  * 获取私聊文件URL
  *
  * 获取指定私聊文件的下载链接
+ *
+ * @param fileId 文件ID
  */
 suspend fun NapCatBotApi.getPrivateFileUrl(fileId: String): NapCatFileApiExpand.PrivateFileUrl {
     return apiRequest("get_private_file_url", mapOf("file_id" to fileId))
@@ -187,6 +199,10 @@ suspend fun NapCatBotApi.getPrivateFileUrl(fileId: String): NapCatFileApiExpand.
  * 获取语音
  *
  * 获取指定语音文件的信息，并支持格式转换
+ *
+ * @param file 文件路径
+ * @param fileId 文件ID
+ * @param outFormat 输出格式
  */
 suspend fun NapCatBotApi.getRecord(
     file: String? = null,

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatFileExtraExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatFileExtraExpand.kt
@@ -25,6 +25,9 @@ class NapCatFileExtraExpand {
 
 /**
  * 取消在线文件
+ *
+ * @param userId 用户ID
+ * @param msgId 消息ID
  */
 suspend fun NapCatBotApi.cancelOnlineFile(userId: String, msgId: String) {
     apiRequestUnit("cancel_online_file", mapOf("user_id" to userId, "msg_id" to msgId))
@@ -32,6 +35,10 @@ suspend fun NapCatBotApi.cancelOnlineFile(userId: String, msgId: String) {
 
 /**
  * 创建闪照任务
+ *
+ * @param files 文件列表
+ * @param name 任务名称
+ * @param thumbPath 缩略图路径
  */
 suspend fun NapCatBotApi.createFlashTask(files: List<String>, name: String? = null, thumbPath: String? = null) {
     apiRequestUnit("create_flash_task", mapOf("files" to files, "name" to name, "thumb_path" to thumbPath))
@@ -39,6 +46,8 @@ suspend fun NapCatBotApi.createFlashTask(files: List<String>, name: String? = nu
 
 /**
  * 下载文件集
+ *
+ * @param filesetId 文件集ID
  */
 suspend fun NapCatBotApi.downloadFileset(filesetId: String): JsonNode {
     return apiRequest("download_fileset", mapOf("fileset_id" to filesetId))
@@ -46,6 +55,8 @@ suspend fun NapCatBotApi.downloadFileset(filesetId: String): JsonNode {
 
 /**
  * 获取文件集 ID
+ *
+ * @param shareCode 分享码
  */
 suspend fun NapCatBotApi.getFilesetId(shareCode: String): NapCatFileExtraExpand.FilesetId {
     return apiRequest("get_fileset_id", mapOf("share_code" to shareCode))
@@ -53,6 +64,8 @@ suspend fun NapCatBotApi.getFilesetId(shareCode: String): NapCatFileExtraExpand.
 
 /**
  * 获取文件集信息
+ *
+ * @param filesetId 文件集ID
  */
 suspend fun NapCatBotApi.getFilesetInfo(filesetId: String): JsonNode {
     return apiRequest("get_fileset_info", mapOf("fileset_id" to filesetId))
@@ -60,6 +73,8 @@ suspend fun NapCatBotApi.getFilesetInfo(filesetId: String): JsonNode {
 
 /**
  * 获取闪照文件列表
+ *
+ * @param filesetId 文件集ID
  */
 suspend fun NapCatBotApi.getFlashFileList(filesetId: String): JsonNode {
     return apiRequest("get_flash_file_list", mapOf("fileset_id" to filesetId))
@@ -67,6 +82,10 @@ suspend fun NapCatBotApi.getFlashFileList(filesetId: String): JsonNode {
 
 /**
  * 获取闪照文件链接
+ *
+ * @param filesetId 文件集ID
+ * @param fileName 文件名
+ * @param fileIndex 文件索引
  */
 suspend fun NapCatBotApi.getFlashFileUrl(
     filesetId: String,
@@ -81,6 +100,8 @@ suspend fun NapCatBotApi.getFlashFileUrl(
 
 /**
  * 获取在线文件消息
+ *
+ * @param userId 用户ID
  */
 suspend fun NapCatBotApi.getOnlineFileMsg(userId: String): JsonNode {
     return apiRequest("get_online_file_msg", mapOf("user_id" to userId))
@@ -88,6 +109,8 @@ suspend fun NapCatBotApi.getOnlineFileMsg(userId: String): JsonNode {
 
 /**
  * 获取文件分享链接
+ *
+ * @param filesetId 文件集ID
  */
 suspend fun NapCatBotApi.getShareLink(filesetId: String): JsonNode {
     return apiRequest("get_share_link", mapOf("fileset_id" to filesetId))
@@ -95,6 +118,11 @@ suspend fun NapCatBotApi.getShareLink(filesetId: String): JsonNode {
 
 /**
  * 移动群文件
+ *
+ * @param groupId 群组ID
+ * @param fileId 文件ID
+ * @param currentParentDirectory 当前父目录
+ * @param targetParentDirectory 目标父目录
  */
 suspend fun NapCatBotApi.moveGroupFile(
     groupId: String,
@@ -115,6 +143,10 @@ suspend fun NapCatBotApi.moveGroupFile(
 
 /**
  * 接收在线文件
+ *
+ * @param userId 用户ID
+ * @param msgId 消息ID
+ * @param elementId 元素ID
  */
 suspend fun NapCatBotApi.receiveOnlineFile(userId: String, msgId: String, elementId: String) {
     apiRequestUnit("receive_online_file", mapOf("user_id" to userId, "msg_id" to msgId, "element_id" to elementId))
@@ -122,6 +154,10 @@ suspend fun NapCatBotApi.receiveOnlineFile(userId: String, msgId: String, elemen
 
 /**
  * 拒绝在线文件
+ *
+ * @param userId 用户ID
+ * @param msgId 消息ID
+ * @param elementId 元素ID
  */
 suspend fun NapCatBotApi.refuseOnlineFile(userId: String, msgId: String, elementId: String) {
     apiRequestUnit("refuse_online_file", mapOf("user_id" to userId, "msg_id" to msgId, "element_id" to elementId))
@@ -129,6 +165,11 @@ suspend fun NapCatBotApi.refuseOnlineFile(userId: String, msgId: String, element
 
 /**
  * 重命名群文件
+ *
+ * @param groupId 群组ID
+ * @param fileId 文件ID
+ * @param currentParentDirectory 当前父目录
+ * @param newName 新文件名
  */
 suspend fun NapCatBotApi.renameGroupFile(
     groupId: String,
@@ -149,6 +190,10 @@ suspend fun NapCatBotApi.renameGroupFile(
 
 /**
  * 发送闪照消息
+ *
+ * @param filesetId 文件集ID
+ * @param userId 用户ID
+ * @param groupId 群组ID
  */
 suspend fun NapCatBotApi.sendFlashMsg(filesetId: String, userId: String? = null, groupId: String? = null) {
     apiRequestUnit("send_flash_msg", mapOf("fileset_id" to filesetId, "user_id" to userId, "group_id" to groupId))
@@ -156,6 +201,10 @@ suspend fun NapCatBotApi.sendFlashMsg(filesetId: String, userId: String? = null,
 
 /**
  * 发送在线文件
+ *
+ * @param userId 用户ID
+ * @param filePath 文件路径
+ * @param fileName 文件名
  */
 suspend fun NapCatBotApi.sendOnlineFile(userId: String, filePath: String, fileName: String? = null) {
     apiRequestUnit("send_online_file", mapOf("user_id" to userId, "file_path" to filePath, "file_name" to fileName))
@@ -163,6 +212,10 @@ suspend fun NapCatBotApi.sendOnlineFile(userId: String, filePath: String, fileNa
 
 /**
  * 发送在线文件夹
+ *
+ * @param userId 用户ID
+ * @param folderPath 文件夹路径
+ * @param folderName 文件夹名称
  */
 suspend fun NapCatBotApi.sendOnlineFolder(userId: String, folderPath: String, folderName: String? = null) {
     apiRequestUnit(
@@ -173,6 +226,9 @@ suspend fun NapCatBotApi.sendOnlineFolder(userId: String, folderPath: String, fo
 
 /**
  * 传输群文件
+ *
+ * @param groupId 群组ID
+ * @param fileId 文件ID
  */
 suspend fun NapCatBotApi.transGroupFile(groupId: String, fileId: String) {
     apiRequestUnit("trans_group_file", mapOf("group_id" to groupId, "file_id" to fileId))

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatGoCqHttpExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatGoCqHttpExpand.kt
@@ -294,6 +294,9 @@ class NapCatGoCqHttpExpand {
  * 处理快速操作
  *
  * 处理来自事件上报的快速操作请求
+ *
+ * @param context 事件上下文
+ * @param operation 操作内容
  */
 suspend fun NapCatBotApi.handleQuickOperation(context: JsonNode, operation: JsonNode) {
     apiRequestUnit(".handle_quick_operation", mapOf("context" to context, "operation" to operation))
@@ -303,6 +306,8 @@ suspend fun NapCatBotApi.handleQuickOperation(context: JsonNode, operation: Json
  * 获取机型显示
  *
  * 获取当前账号可用的设备机型显示名称列表
+ *
+ * @param model 机型名称
  */
 suspend fun NapCatBotApi.getModelShow(model: String? = null): List<NapCatGoCqHttpExpand.ModelShowItemItem> {
     return apiRequest("_get_model_show", mapOf("model" to model))
@@ -312,6 +317,15 @@ suspend fun NapCatBotApi.getModelShow(model: String? = null): List<NapCatGoCqHtt
  * 发送群公告
  *
  * 在指定群聊中发布新的公告
+ *
+ * @param groupId 群组ID
+ * @param content 公告内容
+ * @param image 图片资源
+ * @param pinned 是否置顶
+ * @param type 公告类型
+ * @param confirmRequired 是否需要确认
+ * @param isShowEditCard 是否显示编辑卡片
+ * @param tipWindowType 弹窗类型
  */
 suspend fun NapCatBotApi.sendGroupNotice(
     groupId: String,
@@ -351,6 +365,8 @@ suspend fun NapCatBotApi.setModelShow() {
  * 检查URL安全性
  *
  * 检查指定URL的安全等级
+ *
+ * @param url URL地址
  */
 suspend fun NapCatBotApi.checkUrlSafely(url: String): NapCatGoCqHttpExpand.CheckUrlSafely {
     return apiRequest("check_url_safely", mapOf("url" to url))
@@ -360,6 +376,10 @@ suspend fun NapCatBotApi.checkUrlSafely(url: String): NapCatGoCqHttpExpand.Check
  * 创建群文件目录
  *
  * 在群文件系统中创建新的文件夹
+ *
+ * @param groupId 群组ID
+ * @param folderName 文件夹名称
+ * @param name 文件夹名称
  */
 suspend fun NapCatBotApi.createGroupFileFolder(groupId: String, folderName: String? = null, name: String? = null) {
     apiRequestUnit(
@@ -372,6 +392,11 @@ suspend fun NapCatBotApi.createGroupFileFolder(groupId: String, folderName: Stri
  * 删除好友
  *
  * 从好友列表中删除指定用户
+ *
+ * @param friendId 好友ID
+ * @param userId 用户ID
+ * @param tempBlock 是否临时拉黑
+ * @param tempBothDel 是否双向删除
  */
 suspend fun NapCatBotApi.deleteFriend(
     friendId: String? = null,
@@ -389,6 +414,9 @@ suspend fun NapCatBotApi.deleteFriend(
  * 删除群文件
  *
  * 在群文件系统中删除指定的文件
+ *
+ * @param groupId 群组ID
+ * @param fileId 文件ID
  */
 suspend fun NapCatBotApi.deleteGroupFile(groupId: String, fileId: String) {
     apiRequestUnit("delete_group_file", mapOf("group_id" to groupId, "file_id" to fileId))
@@ -398,6 +426,10 @@ suspend fun NapCatBotApi.deleteGroupFile(groupId: String, fileId: String) {
  * 删除群文件目录
  *
  * 在群文件系统中删除指定的文件夹
+ *
+ * @param groupId 群组ID
+ * @param folderId 文件夹ID
+ * @param folder 文件夹路径
  */
 suspend fun NapCatBotApi.deleteGroupFolder(groupId: String, folderId: String? = null, folder: String? = null) {
     apiRequestUnit("delete_group_folder", mapOf("group_id" to groupId, "folder_id" to folderId, "folder" to folder))
@@ -407,6 +439,11 @@ suspend fun NapCatBotApi.deleteGroupFolder(groupId: String, folderId: String? = 
  * 下载文件
  *
  * 下载网络文件到本地临时目录
+ *
+ * @param url 文件URL
+ * @param base64 Base64内容
+ * @param name 文件名
+ * @param headers 请求头
  */
 suspend fun NapCatBotApi.downloadFile(
     url: String? = null,
@@ -421,6 +458,9 @@ suspend fun NapCatBotApi.downloadFile(
  * 获取合并转发消息
  *
  * 获取合并转发消息的具体内容
+ *
+ * @param messageId 消息ID
+ * @param id 转发ID
  */
 suspend fun NapCatBotApi.getForwardMsg(messageId: String? = null, id: String? = null): NapCatGoCqHttpExpand.ForwardMsg {
     return apiRequest("get_forward_msg", mapOf("message_id" to messageId, "id" to id))
@@ -430,6 +470,14 @@ suspend fun NapCatBotApi.getForwardMsg(messageId: String? = null, id: String? = 
  * 获取好友历史消息
  *
  * 获取指定好友的历史聊天记录
+ *
+ * @param userId 用户ID
+ * @param messageSeq 消息序列号
+ * @param count 获取数量
+ * @param disableGetUrl 是否禁用URL获取
+ * @param parseMultMsg 是否解析合并消息
+ * @param quickReply 是否快速回复
+ * @param reverseOrder 是否倒序
  */
 suspend fun NapCatBotApi.getFriendMsgHistory(
     userId: String,
@@ -459,6 +507,8 @@ suspend fun NapCatBotApi.getFriendMsgHistory(
  * 获取群艾特全体剩余次数
  *
  * 获取指定群聊中艾特全体成员的剩余次数
+ *
+ * @param groupId 群组ID
  */
 suspend fun NapCatBotApi.getGroupAtAllRemain(groupId: String): NapCatGoCqHttpExpand.GroupAtAllRemain {
     return apiRequest("get_group_at_all_remain", mapOf("group_id" to groupId))
@@ -468,6 +518,8 @@ suspend fun NapCatBotApi.getGroupAtAllRemain(groupId: String): NapCatGoCqHttpExp
  * 获取群文件系统信息
  *
  * 获取群聊文件系统的空间及状态信息
+ *
+ * @param groupId 群组ID
  */
 suspend fun NapCatBotApi.getGroupFileSystemInfo(groupId: String): NapCatGoCqHttpExpand.GroupFileSystemInfo {
     return apiRequest("get_group_file_system_info", mapOf("group_id" to groupId))
@@ -477,6 +529,11 @@ suspend fun NapCatBotApi.getGroupFileSystemInfo(groupId: String): NapCatGoCqHttp
  * 获取群文件夹文件列表
  *
  * 获取指定群文件夹下的文件及子文件夹列表
+ *
+ * @param groupId 群组ID
+ * @param folderId 文件夹ID
+ * @param folder 文件夹路径
+ * @param fileCount 文件数量
  */
 suspend fun NapCatBotApi.getGroupFilesByFolder(
     groupId: String,
@@ -494,6 +551,9 @@ suspend fun NapCatBotApi.getGroupFilesByFolder(
  * 获取群荣誉信息
  *
  * 获取指定群聊的荣誉信息，如龙王等
+ *
+ * @param groupId 群组ID
+ * @param type 荣誉类型
  */
 suspend fun NapCatBotApi.getGroupHonorInfo(groupId: String, type: String? = null): NapCatGoCqHttpExpand.GroupHonorInfo {
     return apiRequest("get_group_honor_info", mapOf("group_id" to groupId, "type" to type))
@@ -503,6 +563,14 @@ suspend fun NapCatBotApi.getGroupHonorInfo(groupId: String, type: String? = null
  * 获取群历史消息
  *
  * 获取指定群聊的历史聊天记录
+ *
+ * @param groupId 群组ID
+ * @param messageSeq 消息序列号
+ * @param count 获取数量
+ * @param disableGetUrl 是否禁用URL获取
+ * @param parseMultMsg 是否解析合并消息
+ * @param quickReply 是否快速回复
+ * @param reverseOrder 是否倒序
  */
 suspend fun NapCatBotApi.getGroupMsgHistory(
     groupId: String,
@@ -532,6 +600,9 @@ suspend fun NapCatBotApi.getGroupMsgHistory(
  * 获取群根目录文件列表
  *
  * 获取群文件根目录下的所有文件和文件夹
+ *
+ * @param groupId 群组ID
+ * @param fileCount 文件数量
  */
 suspend fun NapCatBotApi.getGroupRootFiles(groupId: String, fileCount: Long): NapCatGoCqHttpExpand.GroupRootFiles {
     return apiRequest("get_group_root_files", mapOf("group_id" to groupId, "file_count" to fileCount))
@@ -550,6 +621,9 @@ suspend fun NapCatBotApi.getOnlineClients(): List<String> {
  * 获取陌生人信息
  *
  * 获取指定非好友用户的信息
+ *
+ * @param userId 用户ID
+ * @param noCache 是否禁用缓存
  */
 suspend fun NapCatBotApi.getStrangerInfo(userId: String, noCache: Boolean): NapCatGoCqHttpExpand.StrangerInfo {
     return apiRequest("get_stranger_info", mapOf("user_id" to userId, "no_cache" to noCache))
@@ -559,6 +633,16 @@ suspend fun NapCatBotApi.getStrangerInfo(userId: String, noCache: Boolean): NapC
  * 发送合并转发消息
  *
  * 发送合并转发消息
+ *
+ * @param messageType 消息类型
+ * @param userId 用户ID
+ * @param groupId 群组ID
+ * @param message 消息列表
+ * @param autoEscape 是否自动转义
+ * @param source 来源
+ * @param news 新闻列表
+ * @param summary 摘要
+ * @param prompt 提示
  */
 suspend fun NapCatBotApi.sendForwardMsg(
     messageType: String? = null,
@@ -589,6 +673,16 @@ suspend fun NapCatBotApi.sendForwardMsg(
 
 /**
  * 发送群合并转发消息
+ *
+ * @param messageType 消息类型
+ * @param userId 用户ID
+ * @param groupId 群组ID
+ * @param message 消息列表
+ * @param autoEscape 是否自动转义
+ * @param source 来源
+ * @param news 新闻列表
+ * @param summary 摘要
+ * @param prompt 提示
  */
 suspend fun NapCatBotApi.sendGroupForwardMsg(
     messageType: String? = null,
@@ -619,6 +713,16 @@ suspend fun NapCatBotApi.sendGroupForwardMsg(
 
 /**
  * 发送私聊合并转发消息
+ *
+ * @param messageType 消息类型
+ * @param userId 用户ID
+ * @param groupId 群组ID
+ * @param message 消息列表
+ * @param autoEscape 是否自动转义
+ * @param source 来源
+ * @param news 新闻列表
+ * @param summary 摘要
+ * @param prompt 提示
  */
 suspend fun NapCatBotApi.sendPrivateForwardMsg(
     messageType: String? = null,
@@ -651,6 +755,9 @@ suspend fun NapCatBotApi.sendPrivateForwardMsg(
  * 设置群头像
  *
  * 修改指定群聊的头像
+ *
+ * @param file 头像文件
+ * @param groupId 群组ID
  */
 suspend fun NapCatBotApi.setGroupPortrait(file: String, groupId: String) {
     apiRequestUnit("set_group_portrait", mapOf("file" to file, "group_id" to groupId))
@@ -660,6 +767,10 @@ suspend fun NapCatBotApi.setGroupPortrait(file: String, groupId: String) {
  * 设置QQ资料
  *
  * 修改当前账号的昵称、个性签名等资料
+ *
+ * @param nickname 昵称
+ * @param personalNote 个性签名
+ * @param sex 性别
  */
 suspend fun NapCatBotApi.setQqProfile(nickname: String, personalNote: String? = null, sex: Long? = null) {
     apiRequestUnit("set_qq_profile", mapOf("nickname" to nickname, "personal_note" to personalNote, "sex" to sex))
@@ -669,6 +780,13 @@ suspend fun NapCatBotApi.setQqProfile(nickname: String, personalNote: String? = 
  * 上传群文件
  *
  * 上传资源路径或URL指定的文件到指定群聊的文件系统中
+ *
+ * @param groupId 群组ID
+ * @param file 文件路径或URL
+ * @param name 文件名
+ * @param folder 文件夹路径
+ * @param folderId 文件夹ID
+ * @param uploadFile 是否上传文件
  */
 suspend fun NapCatBotApi.uploadGroupFile(
     groupId: String,
@@ -695,6 +813,11 @@ suspend fun NapCatBotApi.uploadGroupFile(
  * 上传私聊文件
  *
  * 上传本地文件到指定私聊会话中
+ *
+ * @param userId 用户ID
+ * @param file 文件路径
+ * @param name 文件名
+ * @param uploadFile 是否上传文件
  */
 suspend fun NapCatBotApi.uploadPrivateFile(userId: String, file: String, name: String, uploadFile: Boolean) {
     apiRequestUnit(

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatGroupApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatGroupApiExpand.kt
@@ -422,6 +422,9 @@ class NapCatGroupApiExpand {
  * 删除群公告
  *
  * 删除群聊中的公告
+ *
+ * @param groupId 群组ID
+ * @param noticeId 公告ID
  */
 suspend fun NapCatBotApi.delGroupNotice(groupId: String, noticeId: String) {
     apiRequestUnit("_del_group_notice", mapOf("group_id" to groupId, "notice_id" to noticeId))
@@ -431,6 +434,8 @@ suspend fun NapCatBotApi.delGroupNotice(groupId: String, noticeId: String) {
  * 获取群公告
  *
  * 获取指定群聊中的公告列表
+ *
+ * @param groupId 群组ID
  */
 suspend fun NapCatBotApi.getGroupNotice(groupId: String): List<NapCatGroupApiExpand.GroupNoticeItemItem> {
     return apiRequest("_get_group_notice", mapOf("group_id" to groupId))
@@ -440,6 +445,11 @@ suspend fun NapCatBotApi.getGroupNotice(groupId: String): List<NapCatGroupApiExp
  * 移出精华消息
  *
  * 将一条消息从群精华消息列表中移出
+ *
+ * @param messageId 消息ID
+ * @param msgSeq 消息序列号
+ * @param msgRandom 随机值
+ * @param groupId 群组ID
  */
 suspend fun NapCatBotApi.deleteEssenceMsg(
     messageId: Long? = null,
@@ -457,6 +467,8 @@ suspend fun NapCatBotApi.deleteEssenceMsg(
  * 获取群精华消息
  *
  * 获取指定群聊中的精华消息列表
+ *
+ * @param groupId 群组ID
  */
 suspend fun NapCatBotApi.getEssenceMsgList(groupId: String): List<NapCatGroupApiExpand.EssenceMsg> {
     return apiRequest("get_essence_msg_list", mapOf("group_id" to groupId))
@@ -466,6 +478,8 @@ suspend fun NapCatBotApi.getEssenceMsgList(groupId: String): List<NapCatGroupApi
  * 获取群详细信息
  *
  * 获取群聊的详细信息，包括成员数、最大成员数等
+ *
+ * @param groupId 群组ID
  */
 suspend fun NapCatBotApi.getGroupDetailInfo(groupId: String): NapCatGroupApiExpand.GroupDetailInfo {
     return apiRequest("get_group_detail_info", mapOf("group_id" to groupId))
@@ -491,6 +505,8 @@ suspend fun NapCatBotApi.getGroupIgnoredNotifies(): NapCatGroupApiExpand.GroupIg
  * 获取群信息
  *
  * 获取群聊的基本信息
+ *
+ * @param groupId 群组ID
  */
 suspend fun NapCatBotApi.getGroupInfo(groupId: String): NapCatGroupApiExpand.GroupInfo {
     return apiRequest("get_group_info", mapOf("group_id" to groupId))
@@ -500,6 +516,8 @@ suspend fun NapCatBotApi.getGroupInfo(groupId: String): NapCatGroupApiExpand.Gro
  * 获取群列表
  *
  * 获取当前账号的群聊列表
+ *
+ * @param noCache 是否禁用缓存
  */
 suspend fun NapCatBotApi.getGroupList(noCache: Boolean? = null): List<NapCatGroupApiExpand.GroupItem> {
     return apiRequest("get_group_list", mapOf("no_cache" to noCache))
@@ -509,6 +527,10 @@ suspend fun NapCatBotApi.getGroupList(noCache: Boolean? = null): List<NapCatGrou
  * 获取群成员信息
  *
  * 获取群聊中指定成员的信息
+ *
+ * @param groupId 群组ID
+ * @param userId 用户ID
+ * @param noCache 是否禁用缓存
  */
 suspend fun NapCatBotApi.getGroupMemberInfo(
     groupId: String,
@@ -522,6 +544,9 @@ suspend fun NapCatBotApi.getGroupMemberInfo(
  * 获取群成员列表
  *
  * 获取群聊中的所有成员列表
+ *
+ * @param groupId 群组ID
+ * @param noCache 是否禁用缓存
  */
 suspend fun NapCatBotApi.getGroupMemberList(
     groupId: String,
@@ -535,6 +560,10 @@ suspend fun NapCatBotApi.getGroupMemberList(
  * 设置群待办
  *
  * 将指定消息设置为群待办
+ *
+ * @param groupId 群组ID
+ * @param messageId 消息ID
+ * @param messageSeq 消息序列号
  */
 suspend fun NapCatBotApi.setGroupTodo(groupId: String, messageId: String? = null, messageSeq: String? = null) {
     apiRequestUnit(
@@ -545,6 +574,8 @@ suspend fun NapCatBotApi.setGroupTodo(groupId: String, messageId: String? = null
 
 /**
  * 获取群禁言列表
+ *
+ * @param groupId 群组ID
  */
 suspend fun NapCatBotApi.getGroupShutList(groupId: String): List<NapCatGroupApiExpand.GroupShut> {
     return apiRequest("get_group_shut_list", mapOf("group_id" to groupId))
@@ -554,6 +585,8 @@ suspend fun NapCatBotApi.getGroupShutList(groupId: String): List<NapCatGroupApiE
  * 设置精华消息
  *
  * 将一条消息设置为群精华消息
+ *
+ * @param messageId 消息ID
  */
 suspend fun NapCatBotApi.setEssenceMsg(messageId: Long) {
     apiRequestUnit("set_essence_msg", mapOf("message_id" to messageId))
@@ -563,6 +596,11 @@ suspend fun NapCatBotApi.setEssenceMsg(messageId: Long) {
  * 处理加群请求
  *
  * 同意或拒绝加群请求或邀请
+ *
+ * @param flag 请求标识
+ * @param approve 是否同意
+ * @param reason 拒绝理由
+ * @param count 处理数量
  */
 suspend fun NapCatBotApi.setGroupAddRequest(
     flag: String,
@@ -580,6 +618,10 @@ suspend fun NapCatBotApi.setGroupAddRequest(
  * 设置群管理员
  *
  * 设置或取消群聊中的管理员
+ *
+ * @param groupId 群组ID
+ * @param userId 用户ID
+ * @param enable 是否启用
  */
 suspend fun NapCatBotApi.setGroupAdmin(groupId: String, userId: String, enable: Boolean? = null) {
     apiRequestUnit("set_group_admin", mapOf("group_id" to groupId, "user_id" to userId, "enable" to enable))
@@ -589,6 +631,10 @@ suspend fun NapCatBotApi.setGroupAdmin(groupId: String, userId: String, enable: 
  * 群组禁言
  *
  * 禁言群聊中的指定成员
+ *
+ * @param groupId 群组ID
+ * @param userId 用户ID
+ * @param duration 禁言时长
  */
 suspend fun NapCatBotApi.setGroupBan(groupId: String, userId: String, duration: Long) {
     apiRequestUnit("set_group_ban", mapOf("group_id" to groupId, "user_id" to userId, "duration" to duration))
@@ -598,6 +644,10 @@ suspend fun NapCatBotApi.setGroupBan(groupId: String, userId: String, duration: 
  * 设置群名片
  *
  * 设置群聊中指定成员的群名片
+ *
+ * @param groupId 群组ID
+ * @param userId 用户ID
+ * @param card 群名片
  */
 suspend fun NapCatBotApi.setGroupCard(groupId: String, userId: String, card: String? = null) {
     apiRequestUnit("set_group_card", mapOf("group_id" to groupId, "user_id" to userId, "card" to card))
@@ -607,6 +657,10 @@ suspend fun NapCatBotApi.setGroupCard(groupId: String, userId: String, card: Str
  * 群组踢人
  *
  * 将指定成员踢出群聊
+ *
+ * @param groupId 群组ID
+ * @param userId 用户ID
+ * @param rejectAddRequest 是否拒绝再次申请
  */
 suspend fun NapCatBotApi.setGroupKick(groupId: String, userId: String, rejectAddRequest: Boolean? = null) {
     apiRequestUnit(
@@ -619,6 +673,9 @@ suspend fun NapCatBotApi.setGroupKick(groupId: String, userId: String, rejectAdd
  * 退出群组
  *
  * 退出或解散指定群聊
+ *
+ * @param groupId 群组ID
+ * @param isDismiss 是否解散
  */
 suspend fun NapCatBotApi.setGroupLeave(groupId: String, isDismiss: Boolean? = null) {
     apiRequestUnit("set_group_leave", mapOf("group_id" to groupId, "is_dismiss" to isDismiss))
@@ -628,6 +685,9 @@ suspend fun NapCatBotApi.setGroupLeave(groupId: String, isDismiss: Boolean? = nu
  * 设置群名称
  *
  * 修改指定群聊的名称
+ *
+ * @param groupId 群组ID
+ * @param groupName 群名称
  */
 suspend fun NapCatBotApi.setGroupName(groupId: String, groupName: String) {
     apiRequestUnit("set_group_name", mapOf("group_id" to groupId, "group_name" to groupName))
@@ -637,6 +697,9 @@ suspend fun NapCatBotApi.setGroupName(groupId: String, groupName: String) {
  * 全员禁言
  *
  * 开启或关闭指定群聊的全员禁言
+ *
+ * @param groupId 群组ID
+ * @param enable 是否启用
  */
 suspend fun NapCatBotApi.setGroupWholeBan(groupId: String, enable: Boolean? = null) {
     apiRequestUnit("set_group_whole_ban", mapOf("group_id" to groupId, "enable" to enable))

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatGroupExtraExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatGroupExtraExpand.kt
@@ -58,6 +58,10 @@ class NapCatGroupExtraExpand {
 
 /**
  * 删除群相册媒体
+ *
+ * @param groupId 群组ID
+ * @param albumId 相册ID
+ * @param lloc 媒体位置标识
  */
 suspend fun NapCatBotApi.delGroupAlbumMedia(groupId: String, albumId: String, lloc: String) {
     apiRequestUnit("del_group_album_media", mapOf("group_id" to groupId, "album_id" to albumId, "lloc" to lloc))
@@ -65,6 +69,11 @@ suspend fun NapCatBotApi.delGroupAlbumMedia(groupId: String, albumId: String, ll
 
 /**
  * 发表群相册评论
+ *
+ * @param groupId 群组ID
+ * @param albumId 相册ID
+ * @param lloc 媒体位置标识
+ * @param content 评论内容
  */
 suspend fun NapCatBotApi.doGroupAlbumComment(groupId: String, albumId: String, lloc: String, content: String) {
     apiRequestUnit(
@@ -75,6 +84,10 @@ suspend fun NapCatBotApi.doGroupAlbumComment(groupId: String, albumId: String, l
 
 /**
  * 获取群相册媒体列表
+ *
+ * @param groupId 群组ID
+ * @param albumId 相册ID
+ * @param attachInfo 附加信息
  */
 suspend fun NapCatBotApi.getGroupAlbumMediaList(
     groupId: String,
@@ -90,6 +103,8 @@ suspend fun NapCatBotApi.getGroupAlbumMediaList(
 
 /**
  * 获取群详细信息 (扩展)
+ *
+ * @param groupId 群组ID
  */
 suspend fun NapCatBotApi.getGroupInfoEx(groupId: String): JsonNode {
     return apiRequest("get_group_info_ex", mapOf("group_id" to groupId))
@@ -97,6 +112,8 @@ suspend fun NapCatBotApi.getGroupInfoEx(groupId: String): JsonNode {
 
 /**
  * 获取群相册列表
+ *
+ * @param groupId 群组ID
  */
 suspend fun NapCatBotApi.getQunAlbumList(groupId: String): List<NapCatGroupExtraExpand.Album> {
     return apiRequest("get_qun_album_list", mapOf("group_id" to groupId))
@@ -104,6 +121,8 @@ suspend fun NapCatBotApi.getQunAlbumList(groupId: String): List<NapCatGroupExtra
 
 /**
  * 群打卡
+ *
+ * @param groupId 群组ID
  */
 suspend fun NapCatBotApi.sendGroupSign(groupId: String) {
     apiRequestUnit("send_group_sign", mapOf("group_id" to groupId))
@@ -111,6 +130,11 @@ suspend fun NapCatBotApi.sendGroupSign(groupId: String) {
 
 /**
  * 设置群加群选项
+ *
+ * @param groupId 群组ID
+ * @param addType 加群方式
+ * @param groupQuestion 验证问题
+ * @param groupAnswer 验证答案
  */
 suspend fun NapCatBotApi.setGroupAddOption(
     groupId: String,
@@ -131,6 +155,12 @@ suspend fun NapCatBotApi.setGroupAddOption(
 
 /**
  * 点赞群相册媒体
+ *
+ * @param groupId 群组ID
+ * @param albumId 相册ID
+ * @param lloc 媒体位置标识
+ * @param id 媒体ID
+ * @param set 是否点赞
  */
 suspend fun NapCatBotApi.setGroupAlbumMediaLike(
     groupId: String,
@@ -149,6 +179,9 @@ suspend fun NapCatBotApi.setGroupAlbumMediaLike(
  * 设置群备注
  *
  * 设置群备注
+ *
+ * @param groupId 群组ID
+ * @param remark 群备注
  */
 suspend fun NapCatBotApi.setGroupRemark(groupId: String, remark: String) {
     apiRequestUnit("set_group_remark", mapOf("group_id" to groupId, "remark" to remark))
@@ -156,6 +189,10 @@ suspend fun NapCatBotApi.setGroupRemark(groupId: String, remark: String) {
 
 /**
  * 设置群机器人加群选项
+ *
+ * @param groupId 群组ID
+ * @param robotMemberSwitch 机器人加群开关
+ * @param robotMemberExamine 机器人加群审核
  */
 suspend fun NapCatBotApi.setGroupRobotAddOption(
     groupId: String,
@@ -174,6 +211,10 @@ suspend fun NapCatBotApi.setGroupRobotAddOption(
 
 /**
  * 设置群搜索选项
+ *
+ * @param groupId 群组ID
+ * @param noCodeFingerOpen 是否开启群号检索
+ * @param noFingerOpen 是否开启群名检索
  */
 suspend fun NapCatBotApi.setGroupSearch(groupId: String, noCodeFingerOpen: Long? = null, noFingerOpen: Long? = null) {
     apiRequestUnit(
@@ -184,6 +225,8 @@ suspend fun NapCatBotApi.setGroupSearch(groupId: String, noCodeFingerOpen: Long?
 
 /**
  * 群打卡
+ *
+ * @param groupId 群组ID
  */
 suspend fun NapCatBotApi.setGroupSign(groupId: String) {
     apiRequestUnit("set_group_sign", mapOf("group_id" to groupId))
@@ -191,6 +234,11 @@ suspend fun NapCatBotApi.setGroupSign(groupId: String) {
 
 /**
  * 上传图片到群相册
+ *
+ * @param groupId 群组ID
+ * @param albumId 相册ID
+ * @param albumName 相册名称
+ * @param file 图片文件
  */
 suspend fun NapCatBotApi.uploadImageToQunAlbum(groupId: String, albumId: String, albumName: String, file: String) {
     apiRequestUnit(

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatMessageApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatMessageApiExpand.kt
@@ -82,11 +82,12 @@ class NapCatMessageApiExpand {
 /**
  * 发送群聊消息
  *
- * @param groupId 群聊ID
+ * @param groupId 群组ID
  * @param message 消息内容
  */
 suspend fun NapCatBotApi.sendGroupMsg(
-    groupId: String = this.receiveMessage.source.id, message: List<NapCatMessage.Message>
+    groupId: String,
+    message: List<NapCatMessage.Message>
 ): Long {
     val body = mapOf("group_id" to groupId, "message" to message)
     return apiRequest<Long>("send_group_msg", body)
@@ -99,7 +100,8 @@ suspend fun NapCatBotApi.sendGroupMsg(
  * @param message 消息内容
  */
 suspend fun NapCatBotApi.sendPrivateMsg(
-    userId: String = this.receiveMessage.sender.id, message: List<NapCatMessage.Message>
+    userId: String,
+    message: List<NapCatMessage.Message>
 ): Long {
     val body = mapOf("user_id" to userId, "message" to message)
     return apiRequest<Long>("send_private_msg", body)
@@ -109,6 +111,9 @@ suspend fun NapCatBotApi.sendPrivateMsg(
  * 发送戳一戳
  *
  * 在群聊或私聊中发送戳一戳动作
+ *
+ * @param groupId 群组ID
+ * @param userId 用户ID
  */
 suspend fun NapCatBotApi.sendPoke(groupId: String? = null, userId: String) {
     apiRequestUnit("send_poke", mapOf("group_id" to groupId, "user_id" to userId))
@@ -125,6 +130,8 @@ suspend fun NapCatBotApi.markAllAsRead() {
  * 撤回消息
  *
  * 撤回已发送的消息
+ *
+ * @param messageId 消息ID
  */
 suspend fun NapCatBotApi.deleteMsg(messageId: Long) {
     apiRequestUnit("delete_msg", mapOf("message_id" to messageId))
@@ -132,6 +139,9 @@ suspend fun NapCatBotApi.deleteMsg(messageId: Long) {
 
 /**
  * 转发单条消息-私聊
+ *
+ * @param messageId 消息ID
+ * @param userId 用户ID
  */
 suspend fun NapCatBotApi.forwardFriendSingleMsg(messageId: Long, userId: String) {
     apiRequestUnit(
@@ -142,6 +152,9 @@ suspend fun NapCatBotApi.forwardFriendSingleMsg(messageId: Long, userId: String)
 
 /**
  * 转发单条消息-群聊
+ *
+ * @param messageId 消息ID
+ * @param groupId 群组ID
  */
 suspend fun NapCatBotApi.forwardGroupSingleMsg(messageId: Long, groupId: String) {
     apiRequestUnit(
@@ -154,6 +167,8 @@ suspend fun NapCatBotApi.forwardGroupSingleMsg(messageId: Long, groupId: String)
  * 获取消息
  *
  * 根据消息 ID 获取消息详细信息
+ *
+ * @param messageId 消息ID
  */
 suspend fun NapCatBotApi.getMsg(messageId: String): NapCatMessage {
     return apiRequest("get_msg", mapOf("message_id" to messageId))
@@ -163,6 +178,10 @@ suspend fun NapCatBotApi.getMsg(messageId: String): NapCatMessage {
  * 标记群聊已读
  *
  * 标记指定渠道的消息为已读
+ *
+ * @param userId 用户ID
+ * @param groupId 群组ID
+ * @param messageId 消息ID
  */
 suspend fun NapCatBotApi.markGroupMsgAsRead(
     userId: String? = null,
@@ -179,6 +198,10 @@ suspend fun NapCatBotApi.markGroupMsgAsRead(
  * 标记消息已读 (Go-CQHTTP)
  *
  * 标记指定渠道的消息为已读
+ *
+ * @param userId 用户ID
+ * @param groupId 群组ID
+ * @param messageId 消息ID
  */
 suspend fun NapCatBotApi.markMsgAsRead(userId: String? = null, groupId: String? = null, messageId: String? = null) {
     apiRequestUnit("mark_msg_as_read", mapOf("user_id" to userId, "group_id" to groupId, "message_id" to messageId))
@@ -188,6 +211,10 @@ suspend fun NapCatBotApi.markMsgAsRead(userId: String? = null, groupId: String? 
  * 标记私聊已读
  *
  * 标记指定渠道的消息为已读
+ *
+ * @param userId 用户ID
+ * @param groupId 群组ID
+ * @param messageId 消息ID
  */
 suspend fun NapCatBotApi.markPrivateMsgAsRead(
     userId: String? = null,

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatMessageExtraExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatMessageExtraExpand.kt
@@ -99,6 +99,8 @@ class NapCatMessageExtraExpand {
  * 分享群 (Ark)
  *
  * 获取群分享的 Ark 内容
+ *
+ * @param groupId 群组ID
  */
 suspend fun NapCatBotApi.arkShareGroup(groupId: String) {
     apiRequestUnit("ArkShareGroup", mapOf("group_id" to groupId))
@@ -108,6 +110,10 @@ suspend fun NapCatBotApi.arkShareGroup(groupId: String) {
  * 分享用户 (Ark)
  *
  * 获取用户推荐的 Ark 内容
+ *
+ * @param userId 用户ID
+ * @param groupId 群组ID
+ * @param phoneNumber 手机号
  */
 suspend fun NapCatBotApi.arkSharePeer(userId: String? = null, groupId: String? = null, phoneNumber: String) {
     apiRequestUnit("ArkSharePeer", mapOf("user_id" to userId, "group_id" to groupId, "phone_number" to phoneNumber))
@@ -115,6 +121,12 @@ suspend fun NapCatBotApi.arkSharePeer(userId: String? = null, groupId: String? =
 
 /**
  * 点击内联键盘按钮
+ *
+ * @param groupId 群组ID
+ * @param botAppid 机器人AppID
+ * @param buttonId 按钮ID
+ * @param callbackData 回调数据
+ * @param msgSeq 消息序列号
  */
 suspend fun NapCatBotApi.clickInlineKeyboardButton(
     groupId: String,
@@ -137,6 +149,12 @@ suspend fun NapCatBotApi.clickInlineKeyboardButton(
 
 /**
  * 获取表情点赞详情
+ *
+ * @param messageId 消息ID
+ * @param emojiId 表情ID
+ * @param emojiType 表情类型
+ * @param count 获取数量
+ * @param cookie 分页Cookie
  */
 suspend fun NapCatBotApi.fetchEmojiLike(
     messageId: Long,
@@ -159,6 +177,12 @@ suspend fun NapCatBotApi.fetchEmojiLike(
 
 /**
  * 获取消息表情点赞列表
+ *
+ * @param groupId 群组ID
+ * @param messageId 消息ID
+ * @param emojiId 表情ID
+ * @param emojiType 表情类型
+ * @param count 获取数量
  */
 suspend fun NapCatBotApi.getEmojiLikes(
     groupId: String? = null,
@@ -183,6 +207,10 @@ suspend fun NapCatBotApi.getEmojiLikes(
  * 分享用户 (Ark)
  *
  * 获取用户推荐的 Ark 内容
+ *
+ * @param userId 用户ID
+ * @param groupId 群组ID
+ * @param phoneNumber 手机号
  */
 suspend fun NapCatBotApi.sendArkShare(userId: String? = null, groupId: String? = null, phoneNumber: String) {
     apiRequestUnit("send_ark_share", mapOf("user_id" to userId, "group_id" to groupId, "phone_number" to phoneNumber))
@@ -192,6 +220,8 @@ suspend fun NapCatBotApi.sendArkShare(userId: String? = null, groupId: String? =
  * 分享群 (Ark)
  *
  * 获取群分享的 Ark 内容
+ *
+ * @param groupId 群组ID
  */
 suspend fun NapCatBotApi.sendGroupArkShare(groupId: String) {
     apiRequestUnit("send_group_ark_share", mapOf("group_id" to groupId))
@@ -199,6 +229,10 @@ suspend fun NapCatBotApi.sendGroupArkShare(groupId: String) {
 
 /**
  * 设置消息表情点赞
+ *
+ * @param messageId 消息ID
+ * @param emojiId 表情ID
+ * @param set 是否点赞
  */
 suspend fun NapCatBotApi.setMsgEmojiLike(messageId: Long, emojiId: Long, set: Boolean? = null) {
     apiRequestUnit("set_msg_emoji_like", mapOf("message_id" to messageId, "emoji_id" to emojiId, "set" to set))

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatStreamApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatStreamApiExpand.kt
@@ -33,6 +33,10 @@ class NapCatStreamApiExpand {
  * 下载文件流
  *
  * 以流式方式从网络或本地下载文件
+ *
+ * @param file 文件路径或URL
+ * @param fileId 文件ID
+ * @param chunkSize 分块大小
  */
 suspend fun NapCatBotApi.downloadFileStream(
     file: String? = null,
@@ -46,6 +50,18 @@ suspend fun NapCatBotApi.downloadFileStream(
  * 上传文件流
  *
  * 以流式方式上传文件数据到机器人
+ *
+ * @param streamId 流ID
+ * @param chunkData 分块数据
+ * @param chunkIndex 分块索引
+ * @param totalChunks 分块总数
+ * @param fileSize 文件大小
+ * @param expectedSha256 期望的SHA256
+ * @param isComplete 是否完成
+ * @param filename 文件名
+ * @param reset 是否重置
+ * @param verifyOnly 是否仅校验
+ * @param fileRetention 文件保留时长
  */
 suspend fun NapCatBotApi.uploadFileStream(
     streamId: String,

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatStreamTransferExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatStreamTransferExpand.kt
@@ -32,6 +32,10 @@ suspend fun NapCatBotApi.cleanStreamTempFile() {
 
 /**
  * 下载图片文件流
+ *
+ * @param file 文件路径或URL
+ * @param fileId 文件ID
+ * @param chunkSize 分块大小
  */
 suspend fun NapCatBotApi.downloadFileImageStream(
     file: String? = null,
@@ -46,6 +50,11 @@ suspend fun NapCatBotApi.downloadFileImageStream(
 
 /**
  * 下载语音文件流
+ *
+ * @param file 文件路径或URL
+ * @param fileId 文件ID
+ * @param chunkSize 分块大小
+ * @param outFormat 输出格式
  */
 suspend fun NapCatBotApi.downloadFileRecordStream(
     file: String? = null,
@@ -61,6 +70,8 @@ suspend fun NapCatBotApi.downloadFileRecordStream(
 
 /**
  * 测试下载流
+ *
+ * @param error 是否触发错误
  */
 suspend fun NapCatBotApi.testDownloadStream(error: Boolean = false): JsonNode {
     return apiRequest("test_download_stream", mapOf("error" to error))

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatSystemApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatSystemApiExpand.kt
@@ -332,6 +332,8 @@ suspend fun NapCatBotApi.cleanCache() {
  * 获取登录凭证
  *
  * 获取登录凭证
+ *
+ * @param domain 域名
  */
 suspend fun NapCatBotApi.getCredentials(domain: String): NapCatSystemApiExpand.Credentials {
     return apiRequest("get_credentials", mapOf("domain" to domain))
@@ -350,6 +352,8 @@ suspend fun NapCatBotApi.getCsrfToken(): NapCatSystemApiExpand.CsrfToken {
  * 获取可疑好友申请
  *
  * 获取系统的可疑好友申请列表
+ *
+ * @param count 获取数量
  */
 suspend fun NapCatBotApi.getDoubtFriendsAddRequest(count: Long): List<NapCatSystemApiExpand.DoubtFriends> {
     return apiRequest("get_doubt_friends_add_request", mapOf("count" to count))
@@ -359,6 +363,8 @@ suspend fun NapCatBotApi.getDoubtFriendsAddRequest(count: Long): List<NapCatSyst
  * 获取群系统消息
  *
  * 获取群系统消息
+ *
+ * @param count 获取数量
  */
 suspend fun NapCatBotApi.getGroupSystemMsg(count: Long): NapCatSystemApiExpand.GroupSystemMsg {
     return apiRequest("get_group_system_msg", mapOf("count" to count))
@@ -404,6 +410,9 @@ suspend fun NapCatBotApi.ncGetPacketStatus(): JsonNode {
  * 处理可疑好友申请
  *
  * 同意或拒绝系统的可疑好友申请
+ *
+ * @param flag 请求标识
+ * @param approve 是否同意
  */
 suspend fun NapCatBotApi.setDoubtFriendsAddRequest(flag: String, approve: Boolean) {
     apiRequestUnit("set_doubt_friends_add_request", mapOf("flag" to flag, "approve" to approve))

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatSystemExtraExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatSystemExtraExpand.kt
@@ -99,6 +99,8 @@ suspend fun NapCatBotApi.botExit() {
 
 /**
  * 获取自定义表情
+ *
+ * @param count 获取数量
  */
 suspend fun NapCatBotApi.fetchCustomFace(count: Long): List<String> {
     return apiRequest("fetch_custom_face", mapOf("count" to count))
@@ -106,6 +108,9 @@ suspend fun NapCatBotApi.fetchCustomFace(count: Long): List<String> {
 
 /**
  * 获取收藏列表
+ *
+ * @param category 收藏分类
+ * @param count 获取数量
  */
 suspend fun NapCatBotApi.getCollectionList(category: String, count: String): String {
     return apiRequest("get_collection_list", mapOf("category" to category, "count" to count))
@@ -148,6 +153,8 @@ suspend fun NapCatBotApi.ncGetRKey(): List<String> {
 
 /**
  * 获取用户在线状态
+ *
+ * @param userId 用户ID
  */
 suspend fun NapCatBotApi.ncGetUserStatus(userId: String): NapCatSystemExtraExpand.NcGetUserStatus {
     return apiRequest("nc_get_user_status", mapOf("user_id" to userId))
@@ -155,6 +162,10 @@ suspend fun NapCatBotApi.ncGetUserStatus(userId: String): NapCatSystemExtraExpan
 
 /**
  * 发送原始数据包
+ *
+ * @param cmd 命令字
+ * @param data 数据内容
+ * @param rsp 响应配置
  */
 suspend fun NapCatBotApi.sendPacket(cmd: String, data: String, rsp: String) {
     apiRequestUnit("send_packet", mapOf("cmd" to cmd, "data" to data, "rsp" to rsp))
@@ -162,6 +173,9 @@ suspend fun NapCatBotApi.sendPacket(cmd: String, data: String, rsp: String) {
 
 /**
  * 设置输入状态
+ *
+ * @param userId 用户ID
+ * @param eventType 事件类型
  */
 suspend fun NapCatBotApi.setInputStatus(userId: String, eventType: Long) {
     apiRequestUnit("set_input_status", mapOf("user_id" to userId, "event_type" to eventType))

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatUserApiExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatUserApiExpand.kt
@@ -160,6 +160,8 @@ class NapCatUserApiExpand {
  * 获取 Cookies
  *
  * 获取指定域名的 Cookies
+ *
+ * @param domain 域名
  */
 suspend fun NapCatBotApi.getCookies(domain: String): NapCatUserApiExpand.Cookies {
     return apiRequest("get_cookies", mapOf("domain" to domain))
@@ -169,6 +171,8 @@ suspend fun NapCatBotApi.getCookies(domain: String): NapCatUserApiExpand.Cookies
  * 获取好友列表
  *
  * 获取当前帐号的好友列表
+ *
+ * @param noCache 是否禁用缓存
  */
 suspend fun NapCatBotApi.getFriendList(noCache: Boolean? = null): List<NapCatUserApiExpand.FriendUser> {
     return apiRequest("get_friend_list", mapOf("no_cache" to noCache))
@@ -178,6 +182,8 @@ suspend fun NapCatBotApi.getFriendList(noCache: Boolean? = null): List<NapCatUse
  * 获取最近会话
  *
  * 获取最近会话
+ *
+ * @param count 获取数量
  */
 suspend fun NapCatBotApi.getRecentContact(count: Long): List<NapCatUserApiExpand.RecentContactItemItem> {
     return apiRequest("get_recent_contact", mapOf("count" to count))
@@ -187,6 +193,9 @@ suspend fun NapCatBotApi.getRecentContact(count: Long): List<NapCatUserApiExpand
  * 点赞
  *
  * 给指定用户点赞
+ *
+ * @param userId 用户ID
+ * @param times 点赞次数
  */
 suspend fun NapCatBotApi.sendLike(userId: String, times: Long) {
     apiRequestUnit("send_like", mapOf("user_id" to userId, "times" to times))
@@ -196,6 +205,10 @@ suspend fun NapCatBotApi.sendLike(userId: String, times: Long) {
  * 处理加好友请求
  *
  * 同意或拒绝加好友请求
+ *
+ * @param flag 请求标识
+ * @param approve 是否同意
+ * @param remark 备注
  */
 suspend fun NapCatBotApi.setFriendAddRequest(flag: String, approve: String? = null, remark: String? = null) {
     apiRequestUnit("set_friend_add_request", mapOf("flag" to flag, "approve" to approve, "remark" to remark))
@@ -205,6 +218,9 @@ suspend fun NapCatBotApi.setFriendAddRequest(flag: String, approve: String? = nu
  * 设置好友备注
  *
  * 设置好友备注
+ *
+ * @param userId 用户ID
+ * @param remark 备注
  */
 suspend fun NapCatBotApi.setFriendRemark(userId: String, remark: String) {
     apiRequestUnit("set_friend_remark", mapOf("user_id" to userId, "remark" to remark))

--- a/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatUserExtraExpand.kt
+++ b/falowp-bot-adapter-nc/src/main/kotlin/com/blr19c/falowp/bot/adapter/nc/expand/NapCatUserExtraExpand.kt
@@ -241,6 +241,10 @@ suspend fun NapCatBotApi.getFriendsWithCategory(): List<NapCatUserExtraExpand.Fr
 
 /**
  * 获取资料点赞
+ *
+ * @param userId 用户ID
+ * @param start 起始位置
+ * @param count 获取数量
  */
 suspend fun NapCatBotApi.getProfileLike(
     userId: String? = null,
@@ -261,6 +265,10 @@ suspend fun NapCatBotApi.getUnidirectionalFriendList(): List<NapCatUserExtraExpa
  * 设置自定义在线状态
  *
  * 设置自定义在线状态
+ *
+ * @param faceId 表情ID
+ * @param faceType 表情类型
+ * @param wording 状态文案
  */
 suspend fun NapCatBotApi.setDiyOnlineStatus(faceId: Long, faceType: Long, wording: String) {
     apiRequestUnit("set_diy_online_status", mapOf("face_id" to faceId, "face_type" to faceType, "wording" to wording))


### PR DESCRIPTION
### Motivation
- Improve API readability and consistency by adding `@param` documentation to NapCat NC expand helper functions based on the NapCat API spec. 
- Remove implicit defaults that referenced `this.receiveMessage` so callers must provide explicit `groupId`/`userId`, avoiding accidental use of the current message context.

### Description
- Added consistent `@param` KDoc comments across multiple files under `falowp-bot-adapter-nc/src/main/kotlin/.../expand` including `NapCatAiExtraExpand.kt`, `NapCatExtraApiExpand.kt`, `NapCatFileApiExpand.kt`, `NapCatFileExtraExpand.kt`, `NapCatGoCqHttpExpand.kt`, `NapCatGroupApiExpand.kt`, `NapCatGroupExtraExpand.kt`, `NapCatMessageApiExpand.kt`, `NapCatMessageExtraExpand.kt`, `NapCatStreamApiExpand.kt`, `NapCatStreamTransferExpand.kt`, `NapCatSystemApiExpand.kt`, `NapCatSystemExtraExpand.kt`, `NapCatUserApiExpand.kt`, `NapCatUserExtraExpand.kt`, and `NapCatExpandApi.kt`.
- Removed implicit defaults for IDs so signatures now require explicit IDs: `sendGroupMsg(groupId: String, ...)`, `sendPrivateMsg(userId: String, ...)`, and `getGroupFileUrl(groupId: String, ...)` (previously defaulted to `this.receiveMessage.source.id` / `this.receiveMessage.sender.id`).
- Added brief KDoc for internal helpers `apiRequestResult`, `apiRequest`, and `apiRequestUnit` to document `type`/`body` parameters and behavior.
- Performed an automated scan and fixed missing `@param` items discovered by the checker script to ensure every `suspend fun` with parameters has matching `@param` tags.

### Testing
- Ran a custom Python verification script that scans `suspend fun` declarations and checks for corresponding `@param` tags, which initially reported missing entries and after fixes returned `No issues` (success).
- Performed `rg`/`sed` inspections to review updated function signatures and KDoc blocks and validated the `groupId`/`userId` defaults were removed where intended.
- Committed the changes successfully (`git commit` completed) and the repository shows the modified files (16 files changed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697af71b2d94832896a477e1ec0486f6)